### PR TITLE
docs: document extraFiles/extraGlobs config for OpenClaw adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,57 @@ contextmate setup
 
 Most users only need `contextmate setup`. The other commands are available for advanced usage and troubleshooting.
 
+## Adapter Configuration
+
+After running `contextmate setup`, you can customize which files each adapter syncs by editing `~/.contextmate/config.toml`.
+
+### OpenClaw Adapter
+
+By default, the OpenClaw adapter syncs:
+- Top-level workspace files: `MEMORY.md`, `IDENTITY.md`, `USER.md`, `SOUL.md`
+- Memory files: `memory/*.md`
+- Skill files: `skills/*/SKILL.md`
+
+To sync additional files (e.g., playbooks, process docs, config files), use `extraFiles` or `extraGlobs` in the config:
+
+```toml
+[adapters.openclaw]
+enabled = true
+workspacePath = "/Users/you/.openclaw/workspace"
+
+# Sync specific files (paths are RELATIVE to workspacePath)
+extraFiles = [
+  "playbooks/bliss.md",
+  "playbooks/system.md",
+  "processes/sourcing.md",
+  "AGENTS.md",
+  "TOOLS.md",
+  "HEARTBEAT.md"
+]
+
+# Or use glob patterns (also relative to workspacePath)
+extraGlobs = [
+  "playbooks/*.md",
+  "processes/*.md"
+]
+```
+
+> **Note:** All paths in `extraFiles` and `extraGlobs` are resolved relative to `workspacePath`, not as absolute paths.
+
+After editing the config, re-import and restart the daemon:
+
+```bash
+contextmate adapter openclaw init
+contextmate daemon stop
+contextmate daemon start
+```
+
+Verify the new files are tracked:
+
+```bash
+contextmate files
+```
+
 ## Architecture
 
 ```


### PR DESCRIPTION
## Problem

The OpenClaw adapter supports `extraFiles` and `extraGlobs` in `config.toml` for syncing files beyond the default set (MEMORY.md, IDENTITY.md, USER.md, SOUL.md, memory/*.md, skills/*/SKILL.md), but this wasn't documented anywhere in the README or docs.

## Key Detail

Paths in `extraFiles` and `extraGlobs` are resolved **relative to `workspacePath`**, not as absolute paths. This caused confusion during setup, as absolute paths silently fail to match any files (the adapter reports '0 new' without any error).

## Changes

Adds a new 'Adapter Configuration' section to the README with:
- Default file list for the OpenClaw adapter
- `extraFiles` example with relative paths
- `extraGlobs` example  
- Note about relative path resolution
- Re-import and daemon restart instructions

## Context

Discovered this while setting up ContextMate to sync OpenClaw workspace files (playbooks, process docs) across machines. Took ~20 minutes to figure out that absolute paths don't work.