### PR TITLE
feat: persistent daemon service with OS keychain integration

### DIFF
--- a/src/bin/contextmate.ts
+++ b/src/bin/contextmate.ts
@@ -1,3 +1,19 @@
 #!/usr/bin/env node
 import { program } from '../cli/index.js';
+import { loadConfig, getConfigPath } from '../config.js';
+import { getVersionFilePath } from '../utils/paths.js';
+import { writeFile, access } from 'node:fs/promises';
+
+// Stamp version file (fire-and-forget) so the persistent service restarts on updates
+(async () => {
+  try {
+    await access(getConfigPath());
+    const config = await loadConfig();
+    const versionFile = getVersionFilePath(config);
+    await writeFile(versionFile, program.version() ?? '', 'utf-8');
+  } catch {
+    // Not initialized yet, skip
+  }
+})();
+
 program.parse();

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -13,6 +13,8 @@ import { MirrorAdapter } from '../adapters/mirror.js';
 import { OpenClawAdapter } from '../adapters/openclaw.js';
 import { ClaudeCodeAdapter } from '../adapters/claude.js';
 import { FileWatcher } from '../sync/watcher.js';
+import { retrievePassphrase, isKeychainAvailable, storePassphrase, deletePassphrase } from '../utils/keychain.js';
+import { installService, uninstallService, isServiceInstalled, writeVersionFile } from './service.js';
 
 async function isInitialized(): Promise<boolean> {
   try {
@@ -45,7 +47,8 @@ async function readPassphrase(prompt: string): Promise<string> {
 const startCommand = new Command('start')
   .description('Start the sync daemon')
   .option('--foreground', 'Run in the foreground (default for MVP)')
-  .action(async () => {
+  .option('--service', 'Running as OS service (read passphrase from keychain)')
+  .action(async (_opts: { foreground?: boolean; service?: boolean }) => {
     try {
       if (!(await isInitialized())) {
         console.error(chalk.red('ContextMate is not initialized. Run "contextmate init" first.'));
@@ -85,11 +88,23 @@ const startCommand = new Command('start')
         encryptedMasterKey: string;
       };
 
-      // Prompt for passphrase
-      const passphrase = await readPassphrase(chalk.bold('Enter passphrase: '));
-      if (!passphrase) {
-        console.error(chalk.red('Error: Passphrase cannot be empty.'));
-        process.exit(1);
+      // Get passphrase (from keychain in service mode, or prompt interactively)
+      const opts = startCommand.opts();
+      let passphrase: string;
+      if (opts.service || !process.stdin.isTTY) {
+        const stored = await retrievePassphrase();
+        if (!stored) {
+          console.error(chalk.red('No passphrase found in OS keychain.'));
+          console.error(chalk.dim('Run "contextmate daemon install" to store passphrase and install service.'));
+          process.exit(1);
+        }
+        passphrase = stored;
+      } else {
+        passphrase = await readPassphrase(chalk.bold('Enter passphrase: '));
+        if (!passphrase) {
+          console.error(chalk.red('Error: Passphrase cannot be empty.'));
+          process.exit(1);
+        }
       }
 
       // Derive keys
@@ -118,12 +133,15 @@ const startCommand = new Command('start')
         process.exit(1);
       }
 
-      // Write PID file
+      // Write PID file and version file
       await writeFile(pidFile, String(process.pid), 'utf-8');
+      await writeVersionFile(config);
 
       // Start sync engine (foreground)
       console.log(chalk.green(`Daemon started (PID: ${process.pid})`));
-      console.log(chalk.dim('Press Ctrl+C to stop.'));
+      if (!opts.service) {
+        console.log(chalk.dim('Press Ctrl+C to stop.'));
+      }
 
       const { SyncEngine } = await import('../sync/index.js');
       const engine = new SyncEngine(config, vaultKey, authToken);
@@ -378,6 +396,127 @@ const statusSubCommand = new Command('status')
       } else {
         console.log(chalk.red(`Daemon is not running (stale PID file, PID: ${pid}).`));
       }
+
+      // Show service status
+      if (await isServiceInstalled()) {
+        console.log(chalk.dim('  Service: installed (persistent)'));
+      } else {
+        console.log(chalk.dim('  Service: not installed'));
+      }
+    } catch (err) {
+      console.error(chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
+      process.exit(1);
+    }
+  });
+
+async function stopRunningDaemon(config: Awaited<ReturnType<typeof loadConfig>>): Promise<void> {
+  const pidFile = getPidFilePath(config);
+  try {
+    const pidStr = await readFile(pidFile, 'utf-8');
+    const pid = parseInt(pidStr.trim(), 10);
+    if (isPidRunning(pid)) {
+      process.kill(pid, 'SIGTERM');
+      for (let i = 0; i < 20; i++) {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        if (!isPidRunning(pid)) break;
+      }
+    }
+    await unlink(pidFile);
+  } catch {
+    // No daemon running
+  }
+}
+
+const installCommand = new Command('install')
+  .description('Install daemon as a persistent OS service')
+  .action(async () => {
+    try {
+      if (!(await isInitialized())) {
+        console.error(chalk.red('ContextMate is not initialized. Run "contextmate setup" first.'));
+        process.exit(1);
+      }
+
+      const config = await loadConfig();
+
+      // Check if already installed
+      if (await isServiceInstalled()) {
+        const answer = await readPassphrase('Service already installed. Reinstall? (y/N): ');
+        if (answer.trim().toLowerCase() !== 'y') return;
+        await uninstallService();
+      }
+
+      // Check keychain availability
+      if (!(await isKeychainAvailable())) {
+        console.error(chalk.red('OS keychain is not available on this system.'));
+        console.error(chalk.dim('macOS requires /usr/bin/security. Linux requires secret-tool (libsecret).'));
+        process.exit(1);
+      }
+
+      // Stop running daemon if any
+      console.log(chalk.dim('Stopping any running daemon...'));
+      await stopRunningDaemon(config);
+
+      // Prompt for passphrase and verify
+      const passphrase = await readPassphrase(chalk.bold('Enter passphrase: '));
+      if (!passphrase) {
+        console.error(chalk.red('Passphrase cannot be empty.'));
+        process.exit(1);
+      }
+
+      const credentialsPath = join(config.data.path, 'credentials.json');
+      const credentials = JSON.parse(await readFile(credentialsPath, 'utf-8')) as {
+        salt: string;
+        encryptedMasterKey: string;
+      };
+      const salt = hexToBytes(credentials.salt);
+      const masterKey = await deriveMasterKey(passphrase, salt);
+      const vaultKey = deriveVaultKey(masterKey);
+      try {
+        decryptString(hexToBytes(credentials.encryptedMasterKey), vaultKey);
+      } catch {
+        console.error(chalk.red('Invalid passphrase.'));
+        process.exit(1);
+      }
+
+      // Store in keychain
+      console.log(chalk.dim('Storing passphrase in OS keychain...'));
+      await storePassphrase(passphrase);
+
+      // Write version file
+      await writeVersionFile(config);
+
+      // Install service
+      console.log(chalk.dim('Installing OS service...'));
+      await installService(config);
+
+      console.log(chalk.green('Daemon service installed and started.'));
+      console.log(chalk.dim('The daemon will start automatically on login/boot.'));
+    } catch (err) {
+      console.error(chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
+      process.exit(1);
+    }
+  });
+
+const uninstallCommand = new Command('uninstall')
+  .description('Remove daemon OS service and keychain entry')
+  .action(async () => {
+    try {
+      if (!(await isServiceInstalled())) {
+        console.log(chalk.dim('No service installed.'));
+        return;
+      }
+
+      console.log(chalk.dim('Removing OS service...'));
+      await uninstallService();
+
+      try {
+        await deletePassphrase();
+        console.log(chalk.dim('Passphrase removed from OS keychain.'));
+      } catch {
+        // Already removed or not stored
+      }
+
+      console.log(chalk.green('Daemon service uninstalled.'));
     } catch (err) {
       console.error(chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
       process.exit(1);
@@ -388,4 +527,6 @@ export const daemonCommand = new Command('daemon')
   .description('Manage the sync daemon')
   .addCommand(startCommand)
   .addCommand(stopCommand)
-  .addCommand(statusSubCommand);
+  .addCommand(statusSubCommand)
+  .addCommand(installCommand)
+  .addCommand(uninstallCommand);

--- a/src/cli/service.ts
+++ b/src/cli/service.ts
@@ -1,0 +1,203 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { writeFile, unlink, access, mkdir } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import type { ContextMateConfig } from '../config.js';
+import { getVersionFilePath } from '../utils/paths.js';
+
+const execFile = promisify(execFileCb);
+
+const PLIST_LABEL = 'dev.contextmate.daemon';
+const PLIST_PATH = join(homedir(), 'Library', 'LaunchAgents', `${PLIST_LABEL}.plist`);
+
+const SYSTEMD_USER_DIR = join(homedir(), '.config', 'systemd', 'user');
+const SYSTEMD_SERVICE = join(SYSTEMD_USER_DIR, 'contextmate.service');
+const SYSTEMD_PATH_UNIT = join(SYSTEMD_USER_DIR, 'contextmate-version.path');
+const SYSTEMD_RESTART_SERVICE = join(SYSTEMD_USER_DIR, 'contextmate-restart.service');
+
+const CLI_VERSION = '0.3.4';
+
+function getScriptPath(): string {
+  const __filename = fileURLToPath(import.meta.url);
+  // From dist/src/cli/service.js -> dist/src/bin/contextmate.js
+  return join(dirname(__filename), '..', 'bin', 'contextmate.js');
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+export async function writeVersionFile(config: ContextMateConfig): Promise<void> {
+  const versionFile = getVersionFilePath(config);
+  await writeFile(versionFile, CLI_VERSION, 'utf-8');
+}
+
+function generatePlist(config: ContextMateConfig): string {
+  const nodePath = process.execPath;
+  const scriptPath = getScriptPath();
+  const versionFile = getVersionFilePath(config);
+  const logDir = config.data.path;
+  const nodeBinDir = dirname(nodePath);
+  const envPath = `/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:${nodeBinDir}`;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${PLIST_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>${escapeXml(nodePath)}</string>
+        <string>${escapeXml(scriptPath)}</string>
+        <string>daemon</string>
+        <string>start</string>
+        <string>--foreground</string>
+        <string>--service</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>WatchPaths</key>
+    <array>
+        <string>${escapeXml(versionFile)}</string>
+    </array>
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+    <key>StandardOutPath</key>
+    <string>${escapeXml(join(logDir, 'daemon.log'))}</string>
+    <key>StandardErrorPath</key>
+    <string>${escapeXml(join(logDir, 'daemon.err.log'))}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>${escapeXml(envPath)}</string>
+        <key>HOME</key>
+        <string>${escapeXml(homedir())}</string>
+    </dict>
+</dict>
+</plist>
+`;
+}
+
+function generateSystemdService(): string {
+  const nodePath = process.execPath;
+  const scriptPath = getScriptPath();
+  const nodeBinDir = dirname(nodePath);
+  const envPath = `/usr/local/bin:/usr/bin:/bin:${nodeBinDir}`;
+
+  return `[Unit]
+Description=ContextMate Sync Daemon
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${nodePath} ${scriptPath} daemon start --foreground --service
+Restart=on-failure
+RestartSec=5
+Environment=PATH=${envPath}
+Environment=HOME=${homedir()}
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function generateSystemdPathUnit(config: ContextMateConfig): string {
+  const versionFile = getVersionFilePath(config);
+  return `[Unit]
+Description=ContextMate version watcher
+
+[Path]
+PathModified=${versionFile}
+Unit=contextmate-restart.service
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+function generateSystemdRestartService(): string {
+  return `[Unit]
+Description=Restart ContextMate on version change
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl --user restart contextmate.service
+`;
+}
+
+export async function installService(config: ContextMateConfig): Promise<void> {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    const plistDir = dirname(PLIST_PATH);
+    await mkdir(plistDir, { recursive: true });
+    await writeFile(PLIST_PATH, generatePlist(config), 'utf-8');
+    await execFile('launchctl', ['load', '-w', PLIST_PATH]);
+  } else if (platform === 'linux') {
+    await mkdir(SYSTEMD_USER_DIR, { recursive: true });
+    await writeFile(SYSTEMD_SERVICE, generateSystemdService(), 'utf-8');
+    await writeFile(SYSTEMD_PATH_UNIT, generateSystemdPathUnit(config), 'utf-8');
+    await writeFile(SYSTEMD_RESTART_SERVICE, generateSystemdRestartService(), 'utf-8');
+    await execFile('systemctl', ['--user', 'daemon-reload']);
+    await execFile('systemctl', ['--user', 'enable', '--now', 'contextmate.service']);
+    await execFile('systemctl', ['--user', 'enable', '--now', 'contextmate-version.path']);
+  } else {
+    throw new Error(`Persistent service is not supported on ${platform}. Use "contextmate daemon start --foreground" instead.`);
+  }
+}
+
+export async function uninstallService(): Promise<void> {
+  const platform = process.platform;
+
+  if (platform === 'darwin') {
+    try {
+      await execFile('launchctl', ['unload', PLIST_PATH]);
+    } catch {
+      // Service may not be loaded
+    }
+    try {
+      await unlink(PLIST_PATH);
+    } catch {
+      // File may not exist
+    }
+  } else if (platform === 'linux') {
+    try { await execFile('systemctl', ['--user', 'disable', '--now', 'contextmate.service']); } catch { /* */ }
+    try { await execFile('systemctl', ['--user', 'disable', '--now', 'contextmate-version.path']); } catch { /* */ }
+    try { await unlink(SYSTEMD_SERVICE); } catch { /* */ }
+    try { await unlink(SYSTEMD_PATH_UNIT); } catch { /* */ }
+    try { await unlink(SYSTEMD_RESTART_SERVICE); } catch { /* */ }
+    try { await execFile('systemctl', ['--user', 'daemon-reload']); } catch { /* */ }
+  }
+}
+
+export async function isServiceInstalled(): Promise<boolean> {
+  const platform = process.platform;
+  const filePath = platform === 'darwin' ? PLIST_PATH : SYSTEMD_SERVICE;
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function restartService(): Promise<void> {
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    try {
+      await execFile('launchctl', ['unload', PLIST_PATH]);
+    } catch { /* */ }
+    await execFile('launchctl', ['load', '-w', PLIST_PATH]);
+  } else if (platform === 'linux') {
+    await execFile('systemctl', ['--user', 'restart', 'contextmate.service']);
+  }
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -207,6 +207,7 @@ export const setupCommand = new Command('setup')
       let userId: string;
       let vaultKey: Uint8Array;
       let deviceId: string | null = null;
+      let passphrase: string = '';
 
       const configPath = getConfigPath();
       let alreadyInitialized = false;
@@ -247,7 +248,7 @@ export const setupCommand = new Command('setup')
 
         // We need the vault key — ask for passphrase
         console.log('');
-        const passphrase = await askSecret(chalk.bold('Passphrase: '));
+        passphrase = await askSecret(chalk.bold('Passphrase: '));
         if (!passphrase || !passphrase.trim()) {
           console.error(chalk.red('Error: Passphrase cannot be empty.'));
           process.exit(1);
@@ -284,7 +285,7 @@ export const setupCommand = new Command('setup')
             process.exit(1);
           }
 
-          const passphrase = await askSecret(chalk.bold('Passphrase: '));
+          passphrase = await askSecret(chalk.bold('Passphrase: '));
           if (!passphrase || !passphrase.trim()) {
             console.error(chalk.red('Error: Passphrase cannot be empty.'));
             process.exit(1);
@@ -349,7 +350,7 @@ export const setupCommand = new Command('setup')
           );
         } else {
           // Create account flow
-          const passphrase = await askSecret(chalk.bold('Choose a passphrase: '));
+          passphrase = await askSecret(chalk.bold('Choose a passphrase: '));
           if (!passphrase || !passphrase.trim()) {
             console.error(chalk.red('Error: Passphrase cannot be empty.'));
             process.exit(1);
@@ -663,7 +664,7 @@ export const setupCommand = new Command('setup')
         await runMcpSetup();
       }
 
-      // ─── Step 8: Start daemon ───
+      // ─── Step 8: Daemon service ───
       console.log(chalk.dim('─'.repeat(40)));
       console.log('');
       console.log(chalk.green.bold('Setup complete!'));
@@ -673,14 +674,60 @@ export const setupCommand = new Command('setup')
       console.log(`  ${chalk.bold('Dashboard:')} https://app.contextmate.dev`);
       console.log('');
 
+      // Try to install as persistent service
+      const { isKeychainAvailable, storePassphrase: storePass } = await import('../utils/keychain.js');
+      const { installService, isServiceInstalled, writeVersionFile } = await import('./service.js');
+      const keychainOk = await isKeychainAvailable();
+
+      if (keychainOk) {
+        // Stop any existing daemon first
+        const pidFile = getPidFilePath(config!);
+        try {
+          const pidStr = await readFile(pidFile, 'utf-8');
+          const pid = parseInt(pidStr.trim(), 10);
+          if (isPidRunning(pid)) {
+            process.kill(pid, 'SIGTERM');
+            for (let i = 0; i < 20; i++) {
+              await new Promise((r) => setTimeout(r, 500));
+              if (!isPidRunning(pid)) break;
+            }
+          }
+          await unlink(pidFile);
+        } catch {
+          // No daemon running
+        }
+
+        // Uninstall existing service if present
+        if (await isServiceInstalled()) {
+          const { uninstallService } = await import('./service.js');
+          await uninstallService();
+        }
+
+        const installDaemon = await ask(chalk.bold('Install daemon as persistent service? (auto-starts on boot) (Y/n): '));
+        if (installDaemon.trim().toLowerCase() !== 'n') {
+          console.log(chalk.dim('Storing passphrase in OS keychain...'));
+          await storePass(passphrase);
+
+          await writeVersionFile(config!);
+
+          console.log(chalk.dim('Installing OS service...'));
+          await installService(config!);
+
+          console.log(chalk.green('Daemon installed as persistent service.'));
+          console.log(chalk.dim('It will start automatically on login/boot and restart on updates.'));
+          return;
+        }
+      }
+
+      // Fallback: offer foreground start
       const startDaemon = await ask(chalk.bold('Start sync daemon now? (Y/n): '));
       if (startDaemon.trim().toLowerCase() === 'n') {
         console.log('');
-        console.log(chalk.dim('Run "contextmate daemon start" whenever you\'re ready to sync.'));
+        console.log(chalk.dim('Run "contextmate daemon start" or "contextmate daemon install" whenever you\'re ready.'));
         return;
       }
 
-      // Start daemon
+      // Start daemon in foreground (existing behavior)
       const pidFile = getPidFilePath(config!);
       try {
         await access(pidFile);
@@ -722,7 +769,6 @@ export const setupCommand = new Command('setup')
           console.log(chalk.dim(`  Mirror: ${initial.created.length} new symlinks`));
         }
 
-        // Watch mirror target for broken symlinks (editor atomic saves)
         mirrorWatcher = new FileWatcher(targetPath, config!.sync.debounceMs);
         mirrorWatcher.start();
 

--- a/src/utils/keychain.ts
+++ b/src/utils/keychain.ts
@@ -1,0 +1,136 @@
+import { execFile as execFileCb } from 'node:child_process';
+import { access, constants } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+
+const SERVICE_NAME = 'contextmate';
+const ACCOUNT_NAME = 'vault-passphrase';
+
+export class KeychainError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KeychainError';
+  }
+}
+
+export async function isKeychainAvailable(): Promise<boolean> {
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    try {
+      await access('/usr/bin/security', constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  if (platform === 'linux') {
+    try {
+      await execFile('which', ['secret-tool']);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+export async function storePassphrase(passphrase: string): Promise<void> {
+  if (!(await isKeychainAvailable())) {
+    throw new KeychainError('OS keychain is not available on this system.');
+  }
+
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    try {
+      await execFile('/usr/bin/security', [
+        'add-generic-password',
+        '-a', ACCOUNT_NAME,
+        '-s', SERVICE_NAME,
+        '-w', passphrase,
+        '-U',
+      ]);
+    } catch (err) {
+      throw new KeychainError(`Failed to store passphrase in Keychain: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  } else if (platform === 'linux') {
+    try {
+      const child = execFileCb('secret-tool', [
+        'store',
+        '--label=ContextMate Vault Passphrase',
+        'service', SERVICE_NAME,
+        'account', ACCOUNT_NAME,
+      ]);
+      child.stdin?.write(passphrase);
+      child.stdin?.end();
+      await new Promise<void>((resolve, reject) => {
+        child.on('exit', (code) => {
+          if (code === 0) resolve();
+          else reject(new KeychainError(`secret-tool store exited with code ${code}`));
+        });
+        child.on('error', reject);
+      });
+    } catch (err) {
+      if (err instanceof KeychainError) throw err;
+      throw new KeychainError(`Failed to store passphrase: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+export async function retrievePassphrase(): Promise<string | null> {
+  if (!(await isKeychainAvailable())) {
+    return null;
+  }
+
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    try {
+      const { stdout } = await execFile('/usr/bin/security', [
+        'find-generic-password',
+        '-a', ACCOUNT_NAME,
+        '-s', SERVICE_NAME,
+        '-w',
+      ]);
+      return stdout.trim();
+    } catch {
+      return null;
+    }
+  } else if (platform === 'linux') {
+    try {
+      const { stdout } = await execFile('secret-tool', [
+        'lookup',
+        'service', SERVICE_NAME,
+        'account', ACCOUNT_NAME,
+      ]);
+      return stdout.trim() || null;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export async function deletePassphrase(): Promise<void> {
+  const platform = process.platform;
+  if (platform === 'darwin') {
+    try {
+      await execFile('/usr/bin/security', [
+        'delete-generic-password',
+        '-a', ACCOUNT_NAME,
+        '-s', SERVICE_NAME,
+      ]);
+    } catch {
+      // Already removed or not stored
+    }
+  } else if (platform === 'linux') {
+    try {
+      await execFile('secret-tool', [
+        'clear',
+        'service', SERVICE_NAME,
+        'account', ACCOUNT_NAME,
+      ]);
+    } catch {
+      // Already removed or not stored
+    }
+  }
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -26,6 +26,10 @@ export function getPidFilePath(config: ContextMateConfig): string {
   return join(config.data.path, 'daemon.pid');
 }
 
+export function getVersionFilePath(config: ContextMateConfig): string {
+  return join(config.data.path, 'version');
+}
+
 export function relativePath(vaultPath: string, absolutePath: string): string {
   return relative(vaultPath, absolutePath);
 }


### PR DESCRIPTION
## Summary

- Adds `contextmate daemon install` / `uninstall` commands for persistent OS service management
- Stores passphrase securely in OS keychain (macOS Keychain, Linux secret-tool) — no plaintext files
- Generates launchd plist (macOS) or systemd user units (Linux) with fully resolved paths
- Auto-starts on login/boot (`RunAtLoad` / `WantedBy=default.target`)
- Crash recovery (`KeepAlive` / `Restart=on-failure`)
- Auto-restarts on version update via `WatchPaths` / `PathModified` on a version file
- `contextmate setup` now offers persistent service installation as the default final step
- Every CLI invocation stamps a version file, so `npm install -g contextmate` triggers daemon restart

## New files
- `src/utils/keychain.ts` — OS keychain abstraction (`security` on macOS, `secret-tool` on Linux)
- `src/cli/service.ts` — Platform service management (plist/systemd generation, install/uninstall)

## Modified files
- `src/cli/daemon.ts` — `--service` flag, `install`/`uninstall` subcommands, keychain passphrase retrieval, enhanced `status`
- `src/cli/setup.ts` — Step 8 offers persistent service as default, falls back to foreground
- `src/bin/contextmate.ts` — Fire-and-forget version file stamp on every invocation
- `src/utils/paths.ts` — `getVersionFilePath()` helper

Supersedes #5 — addresses the same need but built into the product rather than manual docs.

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 168 tests pass
- [ ] Manual: `contextmate daemon install` → prompts passphrase → stores in Keychain → creates plist → daemon starts
- [ ] Manual: `contextmate daemon status` → shows "running" + "Service: installed (persistent)"
- [ ] Manual: close terminal → daemon survives
- [ ] Manual: `contextmate daemon uninstall` → removes plist + Keychain entry → daemon stops
- [ ] Manual: `contextmate setup` → at end, offers persistent service → installs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)