### PR TITLE
Fix daemon silent failure after JWT expires (fixes #9)

### DIFF
--- a/src/sync/client.ts
+++ b/src/sync/client.ts
@@ -1,13 +1,24 @@
+import { readFile, writeFile } from 'node:fs/promises';
 import type { FileMetadata, DeviceInfo } from '../types.js';
+
+export interface TokenRefreshConfig {
+  authJsonPath: string;
+}
 
 export class SyncClient {
   private readonly baseUrl: string;
-  private readonly authToken: string;
+  private authToken: string;
   private readonly maxRetries = 3;
+  private refreshConfig: TokenRefreshConfig | null = null;
+  private refreshing: Promise<void> | null = null;
 
   constructor(baseUrl: string, authToken: string) {
     this.baseUrl = baseUrl.replace(/\/+$/, '');
     this.authToken = authToken;
+  }
+
+  enableTokenRefresh(config: TokenRefreshConfig): void {
+    this.refreshConfig = config;
   }
 
   async uploadFile(
@@ -117,6 +128,49 @@ export class SyncClient {
     return (await response.json()) as DeviceInfo[];
   }
 
+  private async refreshToken(): Promise<boolean> {
+    if (!this.refreshConfig) return false;
+
+    // Deduplicate concurrent refresh attempts
+    if (this.refreshing) {
+      await this.refreshing;
+      return true;
+    }
+
+    this.refreshing = (async () => {
+      try {
+        const authData = JSON.parse(await readFile(this.refreshConfig!.authJsonPath, 'utf-8')) as {
+          authHash: string;
+          userId: string;
+          token: string;
+          deviceId?: string;
+        };
+
+        const response = await fetch(`${this.baseUrl}/api/auth/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ authKeyHash: authData.authHash }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Token refresh failed: ${response.status}`);
+        }
+
+        const result = (await response.json()) as { userId: string; token: string };
+        this.authToken = result.token;
+
+        // Persist new token to auth.json
+        authData.token = result.token;
+        await writeFile(this.refreshConfig!.authJsonPath, JSON.stringify(authData, null, 2), { mode: 0o600 });
+      } finally {
+        this.refreshing = null;
+      }
+    })();
+
+    await this.refreshing;
+    return true;
+  }
+
   private async fetchWithRetry(
     url: string,
     init: RequestInit,
@@ -133,6 +187,16 @@ export class SyncClient {
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
         const response = await fetch(url, requestInit);
+
+        // On 401, try refreshing the token and retry once
+        if (response.status === 401 && attempt === 0) {
+          const refreshed = await this.refreshToken();
+          if (refreshed) {
+            headers.set('Authorization', `Bearer ${this.authToken}`);
+            continue;
+          }
+        }
+
         // Don't retry client errors (4xx) except 429
         if (response.status >= 400 && response.status < 500 && response.status !== 429) {
           return response;

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -29,6 +29,9 @@ export class SyncEngine {
     this.vaultKey = vaultKey;
     this.authToken = authToken || config.server.apiKey || '';
     this.client = new SyncClient(config.server.url, this.authToken);
+    this.client.enableTokenRefresh({
+      authJsonPath: join(config.data.path, 'auth.json'),
+    });
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Summary

- `SyncClient` now auto-refreshes the auth token on 401 responses by calling `/api/auth/login` with the stored `authHash` from `auth.json`
- New token is persisted back to `auth.json` so CLI commands and other devices pick it up
- Concurrent refresh requests are deduplicated (multiple 401s don't cause parallel login calls)
- Refresh is transparent — the failed request retries automatically with the new token

## Root cause

The JWT has a 24h TTL. The daemon reads the token once at startup and never refreshes it. After 24h, every API call returns 401 which `fetchWithRetry` returns without retry (4xx short-circuit). The errors are caught in `syncAll()`'s outer try/catch and silently dropped.

## Changes

- `src/sync/client.ts` — added `refreshToken()` method, `enableTokenRefresh()` config, 401 handling in `fetchWithRetry()`
- `src/sync/engine.ts` — enables token refresh with `auth.json` path in constructor

## Test plan
- [x] `npm run build` passes
- [x] `npm test` — all 167 tests pass
- [ ] Manual: let daemon run for 24h+ → verify sync continues after token expiry
- [ ] Manual: check `auth.json` gets updated with new token after refresh

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)