### PR TITLE
Replace symlinks with copy-sync (Dropbox model) — 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contextmate",
-  "version": "0.3.8",
+  "version": "0.4.0",
   "description": "Zero-knowledge encrypted sync for AI agent context",
   "type": "module",
   "bin": {

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, symlink, readlink, stat, lstat, copyFile, unlink, access, rename, rm } from 'node:fs/promises';
+import { readFile, writeFile, mkdir, copyFile, stat } from 'node:fs/promises';
 import { join, dirname, relative } from 'node:path';
 
 export interface AdapterOptions {
@@ -16,8 +16,8 @@ export interface ImportResult {
   errors: string[];
 }
 
-export interface SymlinkResult {
-  created: string[];
+export interface CopyResult {
+  copied: string[];
   errors: string[];
 }
 
@@ -33,9 +33,10 @@ export abstract class BaseAdapter {
   abstract get name(): string;
   abstract detect(): Promise<string | null>;
   abstract import(workspacePath: string): Promise<ImportResult>;
-  abstract createSymlinks(workspacePath: string): Promise<SymlinkResult>;
-  abstract verifySymlinks(workspacePath: string): Promise<{ valid: string[]; broken: string[] }>;
-  abstract removeSymlinks(workspacePath: string): Promise<void>;
+  abstract copyToWorkspace(workspacePath: string): Promise<CopyResult>;
+  abstract verifySync(workspacePath: string): Promise<{ synced: string[]; stale: string[] }>;
+  abstract disconnect(workspacePath: string): Promise<void>;
+  abstract syncFromVault(workspacePath: string): Promise<{ synced: string[] }>;
 
   protected async backupFile(sourcePath: string, agentName: string): Promise<void> {
     const relativeSrc = relative('/', sourcePath);
@@ -44,41 +45,33 @@ export abstract class BaseAdapter {
     await copyFile(sourcePath, backupDest);
   }
 
-  protected async safeSymlink(target: string, linkPath: string): Promise<void> {
-    await mkdir(dirname(linkPath), { recursive: true });
-
-    try {
-      const linkStat = await lstat(linkPath);
-      if (linkStat.isSymbolicLink()) {
-        await unlink(linkPath);
-      } else if (linkStat.isDirectory()) {
-        // Directory exists — back it up then remove
-        await this.backupFile(linkPath, this.name).catch(() => {});
-        await rm(linkPath, { recursive: true });
-      } else {
-        // Regular file exists — back it up first
-        await this.backupFile(linkPath, this.name);
-        await unlink(linkPath);
-      }
-    } catch {
-      // Path does not exist, nothing to remove
-    }
-
-    await symlink(target, linkPath);
+  protected async copyToVault(sourcePath: string, vaultRelativePath: string): Promise<void> {
+    const dest = join(this.vaultPath, vaultRelativePath);
+    await mkdir(dirname(dest), { recursive: true });
+    await copyFile(sourcePath, dest);
   }
 
-  protected async isSymlink(path: string): Promise<boolean> {
+  protected async copyFromVault(vaultRelativePath: string, destPath: string): Promise<void> {
+    const src = join(this.vaultPath, vaultRelativePath);
+    await mkdir(dirname(destPath), { recursive: true });
+    await copyFile(src, destPath);
+  }
+
+  protected async filesMatch(pathA: string, pathB: string): Promise<boolean> {
     try {
-      const stats = await lstat(path);
-      return stats.isSymbolicLink();
+      const [a, b] = await Promise.all([readFile(pathA), readFile(pathB)]);
+      return Buffer.compare(a, b) === 0;
     } catch {
       return false;
     }
   }
 
-  protected async copyToVault(sourcePath: string, vaultRelativePath: string): Promise<void> {
-    const dest = join(this.vaultPath, vaultRelativePath);
-    await mkdir(dirname(dest), { recursive: true });
-    await copyFile(sourcePath, dest);
+  protected async fileExists(path: string): Promise<boolean> {
+    try {
+      const s = await stat(path);
+      return s.isFile();
+    } catch {
+      return false;
+    }
   }
 }

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,7 +1,7 @@
-import { readFile, readdir, access, stat, unlink, copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { readFile, readdir, access, stat, copyFile, mkdir, writeFile } from 'node:fs/promises';
 import { join, relative, dirname } from 'node:path';
 import { homedir } from 'node:os';
-import { BaseAdapter, type ImportResult, type SymlinkResult } from './base.js';
+import { BaseAdapter, type ImportResult, type CopyResult } from './base.js';
 
 export class ClaudeCodeAdapter extends BaseAdapter {
   private scanPaths: string[];
@@ -55,104 +55,84 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     return result;
   }
 
-  async createSymlinks(claudeDir: string): Promise<SymlinkResult> {
-    const result: SymlinkResult = { created: [], errors: [] };
+  async copyToWorkspace(claudeDir: string): Promise<CopyResult> {
+    const result: CopyResult = { copied: [], errors: [] };
 
     const skillsPath = join(homedir(), '.agents', 'skills');
 
-    // 1. Skills: link vault/skills/* into ~/.agents/skills/ and ~/.claude/skills/
-    await this.symlinkSkills(skillsPath, result);
-    await this.symlinkSkills(join(claudeDir, 'skills'), result);
+    // 1. Skills: copy vault/skills/* into ~/.agents/skills/ and ~/.claude/skills/
+    await this.copySkillsToWorkspace(skillsPath, result);
+    await this.copySkillsToWorkspace(join(claudeDir, 'skills'), result);
 
-    // 2. Rules: link vault/claude/rules/*.md back to ~/.claude/rules/
-    await this.symlinkFiles(
+    // 2. Rules: copy vault/claude/rules/*.md to ~/.claude/rules/
+    await this.copyFilesToWorkspace(
       join(this.vaultPath, 'claude', 'rules'),
       join(claudeDir, 'rules'),
       result,
       'rules/',
     );
 
-    // 3. CLAUDE.md: link vault/claude/CLAUDE.md to ~/.claude/CLAUDE.md
+    // 3. CLAUDE.md: copy vault/claude/CLAUDE.md to ~/.claude/CLAUDE.md
     const vaultClaudeMd = join(this.vaultPath, 'claude', 'CLAUDE.md');
+    const destClaudeMd = join(claudeDir, 'CLAUDE.md');
     try {
       await access(vaultClaudeMd);
-      await this.safeSymlink(vaultClaudeMd, join(claudeDir, 'CLAUDE.md'));
-      result.created.push('CLAUDE.md');
+      if (!(await this.filesMatch(vaultClaudeMd, destClaudeMd))) {
+        await mkdir(dirname(destClaudeMd), { recursive: true });
+        await copyFile(vaultClaudeMd, destClaudeMd);
+        result.copied.push('CLAUDE.md');
+      }
     } catch {
       // No CLAUDE.md in vault
     }
 
-    // 4. Project memories: link vault/claude/projects/*/memory/*.md back to ~/.claude/projects/*/memory/
-    await this.symlinkProjectMemories(claudeDir, result);
+    // 4. Project memories: copy vault/claude/projects/*/memory/*.md to ~/.claude/projects/*/memory/
+    await this.copyProjectMemoriesToWorkspace(claudeDir, result);
 
     return result;
   }
 
-  async verifySymlinks(claudeDir: string): Promise<{ valid: string[]; broken: string[] }> {
-    const valid: string[] = [];
-    const broken: string[] = [];
+  async verifySync(claudeDir: string): Promise<{ synced: string[]; stale: string[] }> {
+    const synced: string[] = [];
+    const stale: string[] = [];
 
     const skillsPath = join(homedir(), '.agents', 'skills');
 
-    // 1. Verify skill symlinks in ~/.agents/skills/ and ~/.claude/skills/
-    await this.verifySkillSymlinks(skillsPath, valid, broken);
-    await this.verifySkillSymlinks(join(claudeDir, 'skills'), valid, broken);
+    // 1. Verify skills in ~/.agents/skills/ and ~/.claude/skills/
+    await this.verifySkillSync(skillsPath, synced, stale);
+    await this.verifySkillSync(join(claudeDir, 'skills'), synced, stale);
 
-    // 2. Verify rule symlinks
-    await this.verifyFileSymlinks(
+    // 2. Verify rules
+    await this.verifyFileSync(
       join(this.vaultPath, 'claude', 'rules'),
       join(claudeDir, 'rules'),
-      valid,
-      broken,
+      synced,
+      stale,
       'rules/',
     );
 
-    // 3. Verify CLAUDE.md symlink
-    const claudeMdLink = join(claudeDir, 'CLAUDE.md');
+    // 3. Verify CLAUDE.md
     const vaultClaudeMd = join(this.vaultPath, 'claude', 'CLAUDE.md');
+    const destClaudeMd = join(claudeDir, 'CLAUDE.md');
     try {
       await access(vaultClaudeMd);
-      if (await this.isSymlink(claudeMdLink)) {
-        try {
-          await stat(claudeMdLink);
-          valid.push('CLAUDE.md');
-        } catch {
-          broken.push('CLAUDE.md');
-        }
+      if (await this.filesMatch(vaultClaudeMd, destClaudeMd)) {
+        synced.push('CLAUDE.md');
       } else {
-        broken.push('CLAUDE.md');
+        stale.push('CLAUDE.md');
       }
     } catch {
       // No CLAUDE.md in vault, skip
     }
 
-    // 4. Verify project memory symlinks
-    await this.verifyProjectMemorySymlinks(claudeDir, valid, broken);
+    // 4. Verify project memories
+    await this.verifyProjectMemorySync(claudeDir, synced, stale);
 
-    return { valid, broken };
+    return { synced, stale };
   }
 
-  async removeSymlinks(claudeDir: string): Promise<void> {
-    const skillsPath = join(homedir(), '.agents', 'skills');
-
-    // 1. Remove skill symlinks from ~/.agents/skills/ and ~/.claude/skills/
-    await this.removeSkillSymlinks(skillsPath);
-    await this.removeSkillSymlinks(join(claudeDir, 'skills'));
-
-    // 2. Remove rule symlinks
-    await this.removeFileSymlinks(
-      join(this.vaultPath, 'claude', 'rules'),
-      join(claudeDir, 'rules'),
-    );
-
-    // 3. Remove CLAUDE.md symlink
-    await this.removeSingleSymlink(
-      join(claudeDir, 'CLAUDE.md'),
-      join(this.vaultPath, 'claude', 'CLAUDE.md'),
-    );
-
-    // 4. Remove project memory symlinks
-    await this.removeProjectMemorySymlinks(claudeDir);
+  async disconnect(_claudeDir: string): Promise<void> {
+    // Workspace files are real copies — nothing to restore.
   }
 
   async syncBack(claudeDir: string): Promise<{ synced: string[] }> {
@@ -184,6 +164,45 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     return { synced };
   }
 
+  async syncFromVault(claudeDir: string): Promise<{ synced: string[] }> {
+    const synced: string[] = [];
+
+    const skillsPath = join(homedir(), '.agents', 'skills');
+
+    // 1. Skills
+    await this.syncSkillsFromVault(skillsPath, synced);
+    await this.syncSkillsFromVault(join(claudeDir, 'skills'), synced);
+
+    // 2. Rules
+    await this.syncFilesFromVault(
+      join(this.vaultPath, 'claude', 'rules'),
+      join(claudeDir, 'rules'),
+      synced,
+      'rules/',
+    );
+
+    // 3. CLAUDE.md
+    const vaultClaudeMd = join(this.vaultPath, 'claude', 'CLAUDE.md');
+    const destClaudeMd = join(claudeDir, 'CLAUDE.md');
+    try {
+      await access(vaultClaudeMd);
+      if (!(await this.filesMatch(vaultClaudeMd, destClaudeMd))) {
+        await mkdir(dirname(destClaudeMd), { recursive: true });
+        await copyFile(vaultClaudeMd, destClaudeMd);
+        synced.push('CLAUDE.md');
+      }
+    } catch {
+      // No CLAUDE.md in vault
+    }
+
+    // 4. Project memories
+    await this.syncProjectMemoriesFromVault(claudeDir, synced);
+
+    return { synced };
+  }
+
+  // --- SyncBack helpers ---
+
   private async syncBackSkills(skillsPath: string, synced: string[]): Promise<void> {
     const vaultSkillsDir = join(this.vaultPath, 'skills');
     let skillNames: string[];
@@ -202,13 +221,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
         continue;
       }
 
-      const linkPath = join(skillsPath, name);
-
-      // For skill directories, check if the directory is a symlink
-      if (await this.isSymlink(linkPath)) continue;
-
-      // It's a real directory — check files inside
-      const skillFile = join(linkPath, 'SKILL.md');
+      const skillFile = join(skillsPath, name, 'SKILL.md');
       const vaultSkillFile = join(vaultSkillDir, 'SKILL.md');
 
       try {
@@ -247,8 +260,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
       if (!name.endsWith('.md')) continue;
       const filePath = join(sourceDir, name);
 
-      if (await this.isSymlink(filePath)) continue;
-
       const vaultRelative = join(vaultPrefix, name);
       const vaultFilePath = join(this.vaultPath, vaultRelative);
 
@@ -257,8 +268,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
         try {
           const vaultContent = await readFile(vaultFilePath);
           if (Buffer.compare(localContent, vaultContent) === 0) {
-            await unlink(filePath);
-            await this.safeSymlink(vaultFilePath, filePath);
             continue;
           }
         } catch {
@@ -267,8 +276,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
 
         await mkdir(dirname(vaultFilePath), { recursive: true });
         await writeFile(vaultFilePath, localContent);
-        await unlink(filePath);
-        await this.safeSymlink(vaultFilePath, filePath);
         synced.push(vaultRelative);
       } catch {
         // Skip unreadable files
@@ -281,8 +288,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     vaultRelative: string,
     synced: string[],
   ): Promise<void> {
-    if (await this.isSymlink(filePath)) return;
-
     const vaultFilePath = join(this.vaultPath, vaultRelative);
 
     try {
@@ -290,8 +295,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
       try {
         const vaultContent = await readFile(vaultFilePath);
         if (Buffer.compare(localContent, vaultContent) === 0) {
-          await unlink(filePath);
-          await this.safeSymlink(vaultFilePath, filePath);
           return;
         }
       } catch {
@@ -300,8 +303,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
 
       await mkdir(dirname(vaultFilePath), { recursive: true });
       await writeFile(vaultFilePath, localContent);
-      await unlink(filePath);
-      await this.safeSymlink(vaultFilePath, filePath);
       synced.push(vaultRelative);
     } catch {
       // File not readable or doesn't exist
@@ -324,19 +325,313 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     }
   }
 
+  // --- SyncFromVault helpers ---
+
+  private async syncSkillsFromVault(skillsPath: string, synced: string[]): Promise<void> {
+    const vaultSkillsDir = join(this.vaultPath, 'skills');
+    let skillNames: string[];
+    try {
+      skillNames = await readdir(vaultSkillsDir);
+    } catch {
+      return;
+    }
+
+    for (const name of skillNames) {
+      const vaultSkillDir = join(vaultSkillsDir, name);
+      try {
+        const s = await stat(vaultSkillDir);
+        if (!s.isDirectory()) continue;
+      } catch {
+        continue;
+      }
+
+      const vaultSkillFile = join(vaultSkillDir, 'SKILL.md');
+      const destSkillFile = join(skillsPath, name, 'SKILL.md');
+
+      try {
+        await access(vaultSkillFile);
+        if (!(await this.filesMatch(vaultSkillFile, destSkillFile))) {
+          await mkdir(dirname(destSkillFile), { recursive: true });
+          await copyFile(vaultSkillFile, destSkillFile);
+          synced.push(join('skills', name, 'SKILL.md'));
+        }
+      } catch {
+        // Skip
+      }
+    }
+  }
+
+  private async syncFilesFromVault(
+    vaultDir: string,
+    targetDir: string,
+    synced: string[],
+    prefix: string,
+  ): Promise<void> {
+    let names: string[];
+    try {
+      names = await readdir(vaultDir);
+    } catch {
+      return;
+    }
+
+    for (const name of names) {
+      const vaultFile = join(vaultDir, name);
+      try {
+        const s = await stat(vaultFile);
+        if (!s.isFile()) continue;
+      } catch {
+        continue;
+      }
+
+      const destFile = join(targetDir, name);
+      try {
+        if (!(await this.filesMatch(vaultFile, destFile))) {
+          await mkdir(dirname(destFile), { recursive: true });
+          await copyFile(vaultFile, destFile);
+          synced.push(`${prefix}${name}`);
+        }
+      } catch {
+        // Skip
+      }
+    }
+  }
+
+  private async syncProjectMemoriesFromVault(claudeDir: string, synced: string[]): Promise<void> {
+    const vaultProjectsDir = join(this.vaultPath, 'claude', 'projects');
+    let projectNames: string[];
+    try {
+      projectNames = await readdir(vaultProjectsDir);
+    } catch {
+      return;
+    }
+
+    for (const projectName of projectNames) {
+      const vaultMemoryDir = join(vaultProjectsDir, projectName, 'memory');
+      const targetMemoryDir = join(claudeDir, 'projects', projectName, 'memory');
+      await this.syncFilesFromVault(
+        vaultMemoryDir,
+        targetMemoryDir,
+        synced,
+        `project:${projectName}/memory/`,
+      );
+    }
+  }
+
+  // --- Copy to workspace helpers ---
+
+  private async copySkillsToWorkspace(skillsPath: string, result: CopyResult): Promise<void> {
+    await mkdir(skillsPath, { recursive: true });
+
+    const vaultSkillsDir = join(this.vaultPath, 'skills');
+    let skillNames: string[];
+    try {
+      skillNames = await readdir(vaultSkillsDir);
+    } catch {
+      return;
+    }
+
+    for (const name of skillNames) {
+      const vaultSkillDir = join(vaultSkillsDir, name);
+      const s = await stat(vaultSkillDir);
+      if (!s.isDirectory()) continue;
+
+      const destDir = join(skillsPath, name);
+
+      try {
+        // Copy all files in the skill directory
+        await this.copyDirectory(vaultSkillDir, destDir);
+        result.copied.push(`skill:${name}`);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        result.errors.push(`skill ${name}: ${message}`);
+      }
+    }
+  }
+
+  private async copyFilesToWorkspace(
+    vaultDir: string,
+    targetDir: string,
+    result: CopyResult,
+    prefix: string,
+  ): Promise<void> {
+    let names: string[];
+    try {
+      names = await readdir(vaultDir);
+    } catch {
+      return;
+    }
+
+    await mkdir(targetDir, { recursive: true });
+
+    for (const name of names) {
+      const vaultFile = join(vaultDir, name);
+      const s = await stat(vaultFile);
+      if (!s.isFile()) continue;
+
+      const destFile = join(targetDir, name);
+
+      try {
+        if (!(await this.filesMatch(vaultFile, destFile))) {
+          await copyFile(vaultFile, destFile);
+          result.copied.push(`${prefix}${name}`);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        result.errors.push(`${prefix}${name}: ${message}`);
+      }
+    }
+  }
+
+  private async copyProjectMemoriesToWorkspace(claudeDir: string, result: CopyResult): Promise<void> {
+    const vaultProjectsDir = join(this.vaultPath, 'claude', 'projects');
+    let projectNames: string[];
+    try {
+      projectNames = await readdir(vaultProjectsDir);
+    } catch {
+      return;
+    }
+
+    for (const projectName of projectNames) {
+      const vaultMemoryDir = join(vaultProjectsDir, projectName, 'memory');
+      let memoryFiles: string[];
+      try {
+        memoryFiles = await readdir(vaultMemoryDir);
+      } catch {
+        continue;
+      }
+
+      const targetMemoryDir = join(claudeDir, 'projects', projectName, 'memory');
+      await mkdir(targetMemoryDir, { recursive: true });
+
+      for (const fileName of memoryFiles) {
+        const vaultFile = join(vaultMemoryDir, fileName);
+        const s = await stat(vaultFile);
+        if (!s.isFile()) continue;
+
+        const destFile = join(targetMemoryDir, fileName);
+        try {
+          if (!(await this.filesMatch(vaultFile, destFile))) {
+            await copyFile(vaultFile, destFile);
+            result.copied.push(`project:${projectName}/memory/${fileName}`);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          result.errors.push(`project ${projectName}/${fileName}: ${message}`);
+        }
+      }
+    }
+  }
+
+  // --- Verify helpers ---
+
+  private async verifySkillSync(
+    skillsPath: string,
+    synced: string[],
+    stale: string[],
+  ): Promise<void> {
+    const vaultSkillsDir = join(this.vaultPath, 'skills');
+    let skillNames: string[];
+    try {
+      skillNames = await readdir(vaultSkillsDir);
+    } catch {
+      return;
+    }
+
+    for (const name of skillNames) {
+      const vaultSkillDir = join(vaultSkillsDir, name);
+      const s = await stat(vaultSkillDir);
+      if (!s.isDirectory()) continue;
+
+      const vaultSkillFile = join(vaultSkillDir, 'SKILL.md');
+      const destSkillFile = join(skillsPath, name, 'SKILL.md');
+
+      if (await this.filesMatch(vaultSkillFile, destSkillFile)) {
+        synced.push(`skill:${name}`);
+      } else {
+        stale.push(`skill:${name}`);
+      }
+    }
+  }
+
+  private async verifyFileSync(
+    vaultDir: string,
+    targetDir: string,
+    synced: string[],
+    stale: string[],
+    prefix: string,
+  ): Promise<void> {
+    let names: string[];
+    try {
+      names = await readdir(vaultDir);
+    } catch {
+      return;
+    }
+
+    for (const name of names) {
+      const vaultFile = join(vaultDir, name);
+      const s = await stat(vaultFile);
+      if (!s.isFile()) continue;
+
+      const targetFile = join(targetDir, name);
+
+      if (await this.filesMatch(vaultFile, targetFile)) {
+        synced.push(`${prefix}${name}`);
+      } else {
+        stale.push(`${prefix}${name}`);
+      }
+    }
+  }
+
+  private async verifyProjectMemorySync(
+    claudeDir: string,
+    synced: string[],
+    stale: string[],
+  ): Promise<void> {
+    const vaultProjectsDir = join(this.vaultPath, 'claude', 'projects');
+    let projectNames: string[];
+    try {
+      projectNames = await readdir(vaultProjectsDir);
+    } catch {
+      return;
+    }
+
+    for (const projectName of projectNames) {
+      const vaultMemoryDir = join(vaultProjectsDir, projectName, 'memory');
+      let memoryFiles: string[];
+      try {
+        memoryFiles = await readdir(vaultMemoryDir);
+      } catch {
+        continue;
+      }
+
+      const targetMemoryDir = join(claudeDir, 'projects', projectName, 'memory');
+
+      for (const fileName of memoryFiles) {
+        const vaultFile = join(vaultMemoryDir, fileName);
+        const s = await stat(vaultFile);
+        if (!s.isFile()) continue;
+
+        const targetFile = join(targetMemoryDir, fileName);
+        const label = `project:${projectName}/memory/${fileName}`;
+
+        if (await this.filesMatch(vaultFile, targetFile)) {
+          synced.push(label);
+        } else {
+          stale.push(label);
+        }
+      }
+    }
+  }
+
   // --- Import helpers ---
 
-  /**
-   * Scan configured scanPaths for project-specific skills.
-   * Looks for <scanPath>/<project>/.claude/skills/<name>/SKILL.md
-   */
   private async importProjectSkills(result: ImportResult): Promise<void> {
     for (const scanPath of this.scanPaths) {
       let projectNames: string[];
       try {
         projectNames = await readdir(scanPath);
       } catch {
-        continue; // Directory doesn't exist or isn't readable
+        continue;
       }
 
       for (const projectName of projectNames) {
@@ -381,7 +676,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     try {
       names = await readdir(rulesDir);
     } catch {
-      return; // No rules directory
+      return;
     }
 
     for (const name of names) {
@@ -391,7 +686,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
       try {
         s = await stat(filePath);
       } catch {
-        continue; // Broken symlink or inaccessible file
+        continue;
       }
       if (!s.isFile()) continue;
 
@@ -410,7 +705,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     try {
       projectNames = await readdir(projectsDir);
     } catch {
-      return; // No projects directory
+      return;
     }
 
     for (const projectName of projectNames) {
@@ -419,7 +714,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
       try {
         memoryFiles = await readdir(memoryDir);
       } catch {
-        continue; // No memory directory in this project
+        continue;
       }
 
       for (const fileName of memoryFiles) {
@@ -429,7 +724,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
         try {
           s = await stat(filePath);
         } catch {
-          continue; // Broken symlink or inaccessible file
+          continue;
         }
         if (!s.isFile()) continue;
 
@@ -453,7 +748,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     try {
       sourceContent = await readFile(sourcePath, 'utf-8');
     } catch {
-      return; // Source file doesn't exist
+      return;
     }
 
     const vaultDest = join(this.vaultPath, vaultRelative);
@@ -469,324 +764,6 @@ export class ClaudeCodeAdapter extends BaseAdapter {
 
     await this.copyToVault(sourcePath, vaultRelative);
     result.imported.push(vaultRelative);
-  }
-
-  // --- Symlink helpers ---
-
-  private async symlinkSkills(skillsPath: string, result: SymlinkResult): Promise<void> {
-    await mkdir(skillsPath, { recursive: true });
-
-    const vaultSkillsDir = join(this.vaultPath, 'skills');
-    let skillNames: string[];
-    try {
-      skillNames = await readdir(vaultSkillsDir);
-    } catch {
-      return;
-    }
-
-    for (const name of skillNames) {
-      const vaultSkillDir = join(vaultSkillsDir, name);
-      const s = await stat(vaultSkillDir);
-      if (!s.isDirectory()) continue;
-
-      const linkPath = join(skillsPath, name);
-
-      try {
-        if (!(await this.isSymlink(linkPath))) {
-          try {
-            await access(linkPath);
-            await this.backupDirectory(linkPath, name);
-          } catch {
-            // Doesn't exist
-          }
-        }
-
-        await this.safeSymlink(vaultSkillDir, linkPath);
-        result.created.push(`skill:${name}`);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        result.errors.push(`skill ${name}: ${message}`);
-      }
-    }
-  }
-
-  private async symlinkFiles(
-    vaultDir: string,
-    targetDir: string,
-    result: SymlinkResult,
-    prefix: string,
-  ): Promise<void> {
-    let names: string[];
-    try {
-      names = await readdir(vaultDir);
-    } catch {
-      return;
-    }
-
-    await mkdir(targetDir, { recursive: true });
-
-    for (const name of names) {
-      const vaultFile = join(vaultDir, name);
-      const s = await stat(vaultFile);
-      if (!s.isFile()) continue;
-
-      const linkPath = join(targetDir, name);
-
-      try {
-        await this.safeSymlink(vaultFile, linkPath);
-        result.created.push(`${prefix}${name}`);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        result.errors.push(`${prefix}${name}: ${message}`);
-      }
-    }
-  }
-
-  private async symlinkProjectMemories(claudeDir: string, result: SymlinkResult): Promise<void> {
-    const vaultProjectsDir = join(this.vaultPath, 'claude', 'projects');
-    let projectNames: string[];
-    try {
-      projectNames = await readdir(vaultProjectsDir);
-    } catch {
-      return;
-    }
-
-    for (const projectName of projectNames) {
-      const vaultMemoryDir = join(vaultProjectsDir, projectName, 'memory');
-      let memoryFiles: string[];
-      try {
-        memoryFiles = await readdir(vaultMemoryDir);
-      } catch {
-        continue;
-      }
-
-      const targetMemoryDir = join(claudeDir, 'projects', projectName, 'memory');
-      await mkdir(targetMemoryDir, { recursive: true });
-
-      for (const fileName of memoryFiles) {
-        const vaultFile = join(vaultMemoryDir, fileName);
-        const s = await stat(vaultFile);
-        if (!s.isFile()) continue;
-
-        const linkPath = join(targetMemoryDir, fileName);
-        try {
-          await this.safeSymlink(vaultFile, linkPath);
-          result.created.push(`project:${projectName}/memory/${fileName}`);
-        } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          result.errors.push(`project ${projectName}/${fileName}: ${message}`);
-        }
-      }
-    }
-  }
-
-  // --- Verify helpers ---
-
-  private async verifySkillSymlinks(
-    skillsPath: string,
-    valid: string[],
-    broken: string[],
-  ): Promise<void> {
-    const vaultSkillsDir = join(this.vaultPath, 'skills');
-    let skillNames: string[];
-    try {
-      skillNames = await readdir(vaultSkillsDir);
-    } catch {
-      return;
-    }
-
-    for (const name of skillNames) {
-      const vaultSkillDir = join(vaultSkillsDir, name);
-      const s = await stat(vaultSkillDir);
-      if (!s.isDirectory()) continue;
-
-      const linkPath = join(skillsPath, name);
-      if (await this.isSymlink(linkPath)) {
-        try {
-          await stat(linkPath);
-          valid.push(`skill:${name}`);
-        } catch {
-          broken.push(`skill:${name}`);
-        }
-      } else {
-        broken.push(`skill:${name}`);
-      }
-    }
-  }
-
-  private async verifyFileSymlinks(
-    vaultDir: string,
-    targetDir: string,
-    valid: string[],
-    broken: string[],
-    prefix: string,
-  ): Promise<void> {
-    let names: string[];
-    try {
-      names = await readdir(vaultDir);
-    } catch {
-      return;
-    }
-
-    for (const name of names) {
-      const vaultFile = join(vaultDir, name);
-      const s = await stat(vaultFile);
-      if (!s.isFile()) continue;
-
-      const linkPath = join(targetDir, name);
-      if (await this.isSymlink(linkPath)) {
-        try {
-          await stat(linkPath);
-          valid.push(`${prefix}${name}`);
-        } catch {
-          broken.push(`${prefix}${name}`);
-        }
-      } else {
-        broken.push(`${prefix}${name}`);
-      }
-    }
-  }
-
-  private async verifyProjectMemorySymlinks(
-    claudeDir: string,
-    valid: string[],
-    broken: string[],
-  ): Promise<void> {
-    const vaultProjectsDir = join(this.vaultPath, 'claude', 'projects');
-    let projectNames: string[];
-    try {
-      projectNames = await readdir(vaultProjectsDir);
-    } catch {
-      return;
-    }
-
-    for (const projectName of projectNames) {
-      const vaultMemoryDir = join(vaultProjectsDir, projectName, 'memory');
-      let memoryFiles: string[];
-      try {
-        memoryFiles = await readdir(vaultMemoryDir);
-      } catch {
-        continue;
-      }
-
-      const targetMemoryDir = join(claudeDir, 'projects', projectName, 'memory');
-
-      for (const fileName of memoryFiles) {
-        const vaultFile = join(vaultMemoryDir, fileName);
-        const s = await stat(vaultFile);
-        if (!s.isFile()) continue;
-
-        const linkPath = join(targetMemoryDir, fileName);
-        const label = `project:${projectName}/memory/${fileName}`;
-        if (await this.isSymlink(linkPath)) {
-          try {
-            await stat(linkPath);
-            valid.push(label);
-          } catch {
-            broken.push(label);
-          }
-        } else {
-          broken.push(label);
-        }
-      }
-    }
-  }
-
-  // --- Remove helpers ---
-
-  private async removeSkillSymlinks(skillsPath: string): Promise<void> {
-    const vaultSkillsDir = join(this.vaultPath, 'skills');
-    let skillNames: string[];
-    try {
-      skillNames = await readdir(vaultSkillsDir);
-    } catch {
-      return;
-    }
-
-    for (const name of skillNames) {
-      const vaultSkillDir = join(vaultSkillsDir, name);
-      const s = await stat(vaultSkillDir);
-      if (!s.isDirectory()) continue;
-
-      const linkPath = join(skillsPath, name);
-      if (!(await this.isSymlink(linkPath))) continue;
-
-      await unlink(linkPath);
-
-      const backupPath = join(this.backupsPath, 'claude', name);
-      try {
-        await access(backupPath);
-        await this.restoreDirectory(backupPath, linkPath);
-      } catch {
-        try {
-          await this.restoreDirectory(vaultSkillDir, linkPath);
-        } catch {
-          // Nothing to restore
-        }
-      }
-    }
-  }
-
-  private async removeFileSymlinks(vaultDir: string, targetDir: string): Promise<void> {
-    let names: string[];
-    try {
-      names = await readdir(vaultDir);
-    } catch {
-      return;
-    }
-
-    for (const name of names) {
-      const linkPath = join(targetDir, name);
-      await this.removeSingleSymlink(linkPath, join(vaultDir, name));
-    }
-  }
-
-  private async removeSingleSymlink(linkPath: string, vaultSource: string): Promise<void> {
-    if (!(await this.isSymlink(linkPath))) return;
-
-    await unlink(linkPath);
-
-    // Restore from backup or vault copy
-    const backupPath = join(this.backupsPath, 'claude', relative(this.vaultPath, vaultSource));
-    try {
-      await access(backupPath);
-      await copyFile(backupPath, linkPath);
-    } catch {
-      try {
-        await access(vaultSource);
-        await copyFile(vaultSource, linkPath);
-      } catch {
-        // Nothing to restore
-      }
-    }
-  }
-
-  private async removeProjectMemorySymlinks(claudeDir: string): Promise<void> {
-    const vaultProjectsDir = join(this.vaultPath, 'claude', 'projects');
-    let projectNames: string[];
-    try {
-      projectNames = await readdir(vaultProjectsDir);
-    } catch {
-      return;
-    }
-
-    for (const projectName of projectNames) {
-      const vaultMemoryDir = join(vaultProjectsDir, projectName, 'memory');
-      let memoryFiles: string[];
-      try {
-        memoryFiles = await readdir(vaultMemoryDir);
-      } catch {
-        continue;
-      }
-
-      const targetMemoryDir = join(claudeDir, 'projects', projectName, 'memory');
-
-      for (const fileName of memoryFiles) {
-        const linkPath = join(targetMemoryDir, fileName);
-        const vaultFile = join(vaultMemoryDir, fileName);
-        await this.removeSingleSymlink(linkPath, vaultFile);
-      }
-    }
   }
 
   // --- Utility ---
@@ -816,21 +793,7 @@ export class ClaudeCodeAdapter extends BaseAdapter {
     return dirs;
   }
 
-  private async backupDirectory(dirPath: string, skillName: string): Promise<void> {
-    const backupDest = join(this.backupsPath, 'claude', skillName);
-    await mkdir(backupDest, { recursive: true });
-
-    const names = await readdir(dirPath);
-    for (const name of names) {
-      const filePath = join(dirPath, name);
-      const s = await stat(filePath);
-      if (s.isFile()) {
-        await copyFile(filePath, join(backupDest, name));
-      }
-    }
-  }
-
-  private async restoreDirectory(sourcePath: string, destPath: string): Promise<void> {
+  private async copyDirectory(sourcePath: string, destPath: string): Promise<void> {
     await mkdir(destPath, { recursive: true });
 
     const names = await readdir(sourcePath);

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,4 +1,4 @@
-export { BaseAdapter, type AdapterOptions, type ImportResult, type SymlinkResult } from './base.js';
+export { BaseAdapter, type AdapterOptions, type ImportResult, type CopyResult } from './base.js';
 export { OpenClawAdapter } from './openclaw.js';
 export { ClaudeCodeAdapter } from './claude.js';
 export { MirrorAdapter } from './mirror.js';

--- a/src/adapters/mirror.ts
+++ b/src/adapters/mirror.ts
@@ -1,7 +1,7 @@
-import { readFile, readdir, stat, unlink, copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { readFile, readdir, stat, copyFile, mkdir, writeFile } from 'node:fs/promises';
 import { join, relative, dirname } from 'node:path';
 import picomatch from 'picomatch';
-import { BaseAdapter, type AdapterOptions, type ImportResult, type SymlinkResult } from './base.js';
+import { BaseAdapter, type AdapterOptions, type ImportResult, type CopyResult } from './base.js';
 
 export class MirrorAdapter extends BaseAdapter {
   private include: string[];
@@ -55,19 +55,24 @@ export class MirrorAdapter extends BaseAdapter {
     return result;
   }
 
-  async createSymlinks(targetPath: string): Promise<SymlinkResult> {
+  async copyToWorkspace(targetPath: string): Promise<CopyResult> {
     this.validatePaths(targetPath);
 
-    const result: SymlinkResult = { created: [], errors: [] };
+    const result: CopyResult = { copied: [], errors: [] };
     const vaultFiles = await this.discoverVaultFiles();
 
     for (const vaultRelative of vaultFiles) {
-      const linkPath = join(targetPath, vaultRelative);
+      const destPath = join(targetPath, vaultRelative);
       const vaultFilePath = join(this.vaultPath, vaultRelative);
 
       try {
-        await this.safeSymlink(vaultFilePath, linkPath);
-        result.created.push(vaultRelative);
+        if (await this.filesMatch(vaultFilePath, destPath)) {
+          continue;
+        }
+
+        await mkdir(dirname(destPath), { recursive: true });
+        await copyFile(vaultFilePath, destPath);
+        result.copied.push(vaultRelative);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         result.errors.push(`${vaultRelative}: ${message}`);
@@ -77,76 +82,48 @@ export class MirrorAdapter extends BaseAdapter {
     return result;
   }
 
-  async verifySymlinks(targetPath: string): Promise<{ valid: string[]; broken: string[] }> {
-    const valid: string[] = [];
-    const broken: string[] = [];
+  async verifySync(targetPath: string): Promise<{ synced: string[]; stale: string[] }> {
+    const synced: string[] = [];
+    const stale: string[] = [];
     const vaultFiles = await this.discoverVaultFiles();
 
     for (const vaultRelative of vaultFiles) {
-      const linkPath = join(targetPath, vaultRelative);
+      const targetFile = join(targetPath, vaultRelative);
+      const vaultFile = join(this.vaultPath, vaultRelative);
 
-      if (await this.isSymlink(linkPath)) {
-        try {
-          await stat(linkPath);
-          valid.push(vaultRelative);
-        } catch {
-          broken.push(vaultRelative);
-        }
+      if (await this.filesMatch(targetFile, vaultFile)) {
+        synced.push(vaultRelative);
       } else {
-        broken.push(vaultRelative);
+        stale.push(vaultRelative);
       }
     }
 
-    return { valid, broken };
+    return { synced, stale };
   }
 
-  async removeSymlinks(targetPath: string): Promise<void> {
-    const vaultFiles = await this.discoverVaultFiles();
-
-    for (const vaultRelative of vaultFiles) {
-      const linkPath = join(targetPath, vaultRelative);
-
-      if (!(await this.isSymlink(linkPath))) {
-        continue;
-      }
-
-      await unlink(linkPath);
-
-      // Restore from vault copy
-      try {
-        const vaultFilePath = join(this.vaultPath, vaultRelative);
-        await mkdir(dirname(linkPath), { recursive: true });
-        await copyFile(vaultFilePath, linkPath);
-      } catch {
-        // Nothing to restore
-      }
-    }
+  async disconnect(_targetPath: string): Promise<void> {
+    // Workspace files are real copies — nothing to restore.
   }
 
-  async refreshSymlinks(targetPath: string): Promise<SymlinkResult> {
+  async refreshCopies(targetPath: string): Promise<CopyResult> {
     this.validatePaths(targetPath);
 
-    const result: SymlinkResult = { created: [], errors: [] };
+    const result: CopyResult = { copied: [], errors: [] };
     const vaultFiles = await this.discoverVaultFiles();
 
     for (const vaultRelative of vaultFiles) {
-      const linkPath = join(targetPath, vaultRelative);
-
-      // Skip if valid symlink already exists
-      if (await this.isSymlink(linkPath)) {
-        try {
-          await stat(linkPath);
-          continue;
-        } catch {
-          // Broken symlink, recreate
-        }
-      }
-
+      const destPath = join(targetPath, vaultRelative);
       const vaultFilePath = join(this.vaultPath, vaultRelative);
 
       try {
-        await this.safeSymlink(vaultFilePath, linkPath);
-        result.created.push(vaultRelative);
+        // Skip if already in sync
+        if (await this.filesMatch(vaultFilePath, destPath)) {
+          continue;
+        }
+
+        await mkdir(dirname(destPath), { recursive: true });
+        await copyFile(vaultFilePath, destPath);
+        result.copied.push(vaultRelative);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         result.errors.push(`${vaultRelative}: ${message}`);
@@ -161,25 +138,16 @@ export class MirrorAdapter extends BaseAdapter {
     const targetFiles = await this.walkDir(targetPath, targetPath);
 
     for (const relativePath of targetFiles) {
-      const linkPath = join(targetPath, relativePath);
-
-      // Skip if it's still a valid symlink — no editor breakage
-      if (await this.isSymlink(linkPath)) continue;
-
-      // This is a regular file where a symlink should be.
-      // The editor broke the symlink on save.
+      const filePath = join(targetPath, relativePath);
       const vaultFilePath = join(this.vaultPath, relativePath);
 
       try {
-        const targetContent = await readFile(linkPath);
+        const targetContent = await readFile(filePath);
 
         // Compare with vault — skip if identical
         try {
           const vaultContent = await readFile(vaultFilePath);
           if (Buffer.compare(targetContent, vaultContent) === 0) {
-            // Content is the same, just re-create the symlink
-            await unlink(linkPath);
-            await this.safeSymlink(vaultFilePath, linkPath);
             continue;
           }
         } catch {
@@ -190,13 +158,33 @@ export class MirrorAdapter extends BaseAdapter {
         await mkdir(dirname(vaultFilePath), { recursive: true });
         await writeFile(vaultFilePath, targetContent);
 
-        // Replace the regular file with a symlink back to vault
-        await unlink(linkPath);
-        await this.safeSymlink(vaultFilePath, linkPath);
-
         synced.push(relativePath);
       } catch {
         // Skip unreadable files
+      }
+    }
+
+    return { synced };
+  }
+
+  async syncFromVault(targetPath: string): Promise<{ synced: string[] }> {
+    const synced: string[] = [];
+    const vaultFiles = await this.discoverVaultFiles();
+
+    for (const vaultRelative of vaultFiles) {
+      const destPath = join(targetPath, vaultRelative);
+      const vaultFilePath = join(this.vaultPath, vaultRelative);
+
+      try {
+        if (await this.filesMatch(vaultFilePath, destPath)) {
+          continue;
+        }
+
+        await mkdir(dirname(destPath), { recursive: true });
+        await copyFile(vaultFilePath, destPath);
+        synced.push(vaultRelative);
+      } catch {
+        // Skip errors
       }
     }
 

--- a/src/adapters/openclaw.ts
+++ b/src/adapters/openclaw.ts
@@ -1,8 +1,8 @@
-import { readFile, readdir, access, stat, unlink, copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { readFile, readdir, access, stat, copyFile, mkdir, writeFile } from 'node:fs/promises';
 import { join, relative, dirname } from 'node:path';
 import { homedir } from 'node:os';
 import picomatch from 'picomatch';
-import { BaseAdapter, type AdapterOptions, type ImportResult, type SymlinkResult } from './base.js';
+import { BaseAdapter, type AdapterOptions, type ImportResult, type CopyResult } from './base.js';
 
 export class OpenClawAdapter extends BaseAdapter {
   private extraFiles: string[];
@@ -62,22 +62,24 @@ export class OpenClawAdapter extends BaseAdapter {
     return result;
   }
 
-  async createSymlinks(workspacePath: string): Promise<SymlinkResult> {
-    const result: SymlinkResult = { created: [], errors: [] };
-    const filesToLink = await this.discoverFiles(workspacePath);
+  async copyToWorkspace(workspacePath: string): Promise<CopyResult> {
+    const result: CopyResult = { copied: [], errors: [] };
+    const vaultFiles = await this.discoverVaultFiles();
 
-    for (const filePath of filesToLink) {
-      const relativeSrc = relative(workspacePath, filePath);
-      const vaultRelative = join('openclaw', relativeSrc);
+    for (const vaultRelative of vaultFiles) {
+      const relativeSrc = vaultRelative.replace(/^openclaw\//, '');
+      const destPath = join(workspacePath, relativeSrc);
       const vaultPath = join(this.vaultPath, vaultRelative);
 
       try {
-        if (!(await this.isSymlink(filePath))) {
-          await this.backupFile(filePath, 'openclaw');
+        // Skip if workspace file already matches vault
+        if (await this.filesMatch(vaultPath, destPath)) {
+          continue;
         }
 
-        await this.safeSymlink(vaultPath, filePath);
-        result.created.push(relativeSrc);
+        await mkdir(dirname(destPath), { recursive: true });
+        await copyFile(vaultPath, destPath);
+        result.copied.push(relativeSrc);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         result.errors.push(`${relativeSrc}: ${message}`);
@@ -87,57 +89,29 @@ export class OpenClawAdapter extends BaseAdapter {
     return result;
   }
 
-  async verifySymlinks(workspacePath: string): Promise<{ valid: string[]; broken: string[] }> {
-    const valid: string[] = [];
-    const broken: string[] = [];
-    const filesToCheck = await this.discoverFiles(workspacePath);
+  async verifySync(workspacePath: string): Promise<{ synced: string[]; stale: string[] }> {
+    const synced: string[] = [];
+    const stale: string[] = [];
+    const vaultFiles = await this.discoverVaultFiles();
 
-    for (const filePath of filesToCheck) {
-      const relativeSrc = relative(workspacePath, filePath);
+    for (const vaultRelative of vaultFiles) {
+      const relativeSrc = vaultRelative.replace(/^openclaw\//, '');
+      const workspaceFile = join(workspacePath, relativeSrc);
+      const vaultFile = join(this.vaultPath, vaultRelative);
 
-      if (await this.isSymlink(filePath)) {
-        try {
-          await stat(filePath);
-          valid.push(relativeSrc);
-        } catch {
-          broken.push(relativeSrc);
-        }
+      if (await this.filesMatch(workspaceFile, vaultFile)) {
+        synced.push(relativeSrc);
       } else {
-        broken.push(relativeSrc);
+        stale.push(relativeSrc);
       }
     }
 
-    return { valid, broken };
+    return { synced, stale };
   }
 
-  async removeSymlinks(workspacePath: string): Promise<void> {
-    const filesToRestore = await this.discoverVaultFiles();
-
-    for (const vaultRelative of filesToRestore) {
-      const relativeSrc = vaultRelative.replace(/^openclaw\//, '');
-      const originalPath = join(workspacePath, relativeSrc);
-
-      if (!(await this.isSymlink(originalPath))) {
-        continue;
-      }
-
-      await unlink(originalPath);
-
-      // Try to restore from backup
-      const backupPath = join(this.backupsPath, 'openclaw', relative('/', originalPath));
-      try {
-        await mkdir(dirname(originalPath), { recursive: true });
-        await copyFile(backupPath, originalPath);
-      } catch {
-        // No backup -- move vault file back
-        const vaultFilePath = join(this.vaultPath, vaultRelative);
-        try {
-          await copyFile(vaultFilePath, originalPath);
-        } catch {
-          // Vault file also missing
-        }
-      }
-    }
+  async disconnect(_workspacePath: string): Promise<void> {
+    // Workspace files are real copies — nothing to restore.
+    // Config disabling is handled by the caller.
   }
 
   async syncBack(workspacePath: string): Promise<{ synced: string[] }> {
@@ -145,10 +119,6 @@ export class OpenClawAdapter extends BaseAdapter {
     const filesToCheck = await this.discoverFiles(workspacePath);
 
     for (const filePath of filesToCheck) {
-      // Skip if it's still a valid symlink
-      if (await this.isSymlink(filePath)) continue;
-
-      // Regular file where a symlink should be — editor/tool broke the symlink
       const relativeSrc = relative(workspacePath, filePath);
       const vaultRelative = join('openclaw', relativeSrc);
       const vaultFilePath = join(this.vaultPath, vaultRelative);
@@ -160,9 +130,6 @@ export class OpenClawAdapter extends BaseAdapter {
         try {
           const vaultContent = await readFile(vaultFilePath);
           if (Buffer.compare(workspaceContent, vaultContent) === 0) {
-            // Content is the same, just re-create the symlink
-            await unlink(filePath);
-            await this.safeSymlink(vaultFilePath, filePath);
             continue;
           }
         } catch {
@@ -173,13 +140,35 @@ export class OpenClawAdapter extends BaseAdapter {
         await mkdir(dirname(vaultFilePath), { recursive: true });
         await writeFile(vaultFilePath, workspaceContent);
 
-        // Replace the regular file with a symlink back to vault
-        await unlink(filePath);
-        await this.safeSymlink(vaultFilePath, filePath);
-
         synced.push(vaultRelative);
       } catch {
         // Skip unreadable files
+      }
+    }
+
+    return { synced };
+  }
+
+  async syncFromVault(workspacePath: string): Promise<{ synced: string[] }> {
+    const synced: string[] = [];
+    const vaultFiles = await this.discoverVaultFiles();
+
+    for (const vaultRelative of vaultFiles) {
+      const relativeSrc = vaultRelative.replace(/^openclaw\//, '');
+      const destPath = join(workspacePath, relativeSrc);
+      const vaultPath = join(this.vaultPath, vaultRelative);
+
+      try {
+        // Skip if workspace file already matches vault
+        if (await this.filesMatch(vaultPath, destPath)) {
+          continue;
+        }
+
+        await mkdir(dirname(destPath), { recursive: true });
+        await copyFile(vaultPath, destPath);
+        synced.push(relativeSrc);
+      } catch {
+        // Skip errors
       }
     }
 

--- a/src/cli/adapter.ts
+++ b/src/cli/adapter.ts
@@ -188,7 +188,7 @@ function createAdapterSubcommands(agentName: string, displayName: string): Comma
 
   cmd
     .command('init')
-    .description(`Import and symlink ${displayName} workspace`)
+    .description(`Import and sync ${displayName} workspace`)
     .action(async () => {
       try {
         if (!(await isInitialized())) {
@@ -287,14 +287,14 @@ function createAdapterSubcommands(agentName: string, displayName: string): Comma
           }
         }
 
-        // Create symlinks
-        console.log(chalk.dim('Creating symlinks...'));
-        const symlinkResult = await adapter.createSymlinks(workspacePath);
+        // Copy files to workspace
+        console.log(chalk.dim('Syncing files to workspace...'));
+        const copyResult = await adapter.copyToWorkspace(workspacePath);
 
-        console.log(`  ${chalk.green(`${symlinkResult.created.length} symlinks created`)}`);
+        console.log(`  ${chalk.green(`${copyResult.copied.length} files synced`)}`);
 
-        if (symlinkResult.errors.length > 0) {
-          for (const err of symlinkResult.errors) {
+        if (copyResult.errors.length > 0) {
+          for (const err of copyResult.errors) {
             console.log(`  ${chalk.red('Error:')} ${err}`);
           }
         }
@@ -323,7 +323,7 @@ function createAdapterSubcommands(agentName: string, displayName: string): Comma
 
   cmd
     .command('status')
-    .description(`Show ${displayName} symlink status`)
+    .description(`Show ${displayName} sync status`)
     .action(async () => {
       try {
         if (!(await isInitialized())) {
@@ -341,19 +341,19 @@ function createAdapterSubcommands(agentName: string, displayName: string): Comma
         }
 
         const workspacePath = getWorkspacePath(agentName, config);
-        const result = await adapter.verifySymlinks(workspacePath);
+        const result = await adapter.verifySync(workspacePath);
 
         console.log('');
         console.log(chalk.bold(`${displayName} Adapter Status`));
         console.log(chalk.dim('─'.repeat(40)));
         console.log(`  ${agentName === 'mirror' ? 'Target:' : 'Workspace:'} ${workspacePath}`);
-        console.log(`  Valid symlinks:  ${chalk.green(String(result.valid.length))}`);
-        console.log(`  Broken symlinks: ${chalk.red(String(result.broken.length))}`);
+        console.log(`  Synced files: ${chalk.green(String(result.synced.length))}`);
+        console.log(`  Stale files:  ${chalk.red(String(result.stale.length))}`);
 
-        if (result.broken.length > 0) {
+        if (result.stale.length > 0) {
           console.log('');
-          console.log(chalk.red('  Broken:'));
-          for (const b of result.broken) {
+          console.log(chalk.red('  Stale:'));
+          for (const b of result.stale) {
             console.log(`    - ${b}`);
           }
         }
@@ -366,7 +366,7 @@ function createAdapterSubcommands(agentName: string, displayName: string): Comma
 
   cmd
     .command('remove')
-    .description(`Remove ${displayName} symlinks and restore originals`)
+    .description(`Disconnect ${displayName} adapter`)
     .action(async () => {
       try {
         if (!(await isInitialized())) {
@@ -384,13 +384,13 @@ function createAdapterSubcommands(agentName: string, displayName: string): Comma
 
         const workspacePath = getWorkspacePath(agentName, config);
 
-        console.log(chalk.dim('Removing symlinks and restoring originals...'));
-        await adapter.removeSymlinks(workspacePath);
+        console.log(chalk.dim('Disconnecting adapter...'));
+        await adapter.disconnect(workspacePath);
 
         setAdapterEnabled(agentName, config, false);
         await saveConfig(config);
 
-        console.log(chalk.green(`${displayName} adapter removed.`));
+        console.log(chalk.green(`${displayName} adapter disconnected. Workspace files are unchanged.`));
       } catch (err) {
         console.error(chalk.red(`Error: ${err instanceof Error ? err.message : String(err)}`));
         process.exit(1);

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -163,12 +163,12 @@ const startCommand = new Command('start')
         if (backed.synced.length > 0) {
           console.log(chalk.dim(`  Mirror: ${backed.synced.length} file${backed.synced.length === 1 ? '' : 's'} synced back`));
         }
-        const initial = await mirrorAdapter.refreshSymlinks(targetPath);
-        if (initial.created.length > 0) {
-          console.log(chalk.dim(`  Mirror: ${initial.created.length} new symlinks`));
+        const initial = await mirrorAdapter.refreshCopies(targetPath);
+        if (initial.copied.length > 0) {
+          console.log(chalk.dim(`  Mirror: ${initial.copied.length} files synced`));
         }
 
-        // Watch the mirror target for real-time detection of broken symlinks
+        // Watch the mirror target for real-time change detection
         mirrorWatcher = new FileWatcher(targetPath, config.sync.debounceMs);
         mirrorWatcher.start();
 
@@ -185,11 +185,11 @@ const startCommand = new Command('start')
         mirrorWatcher.on('file-changed', () => void handleMirrorChange());
         mirrorWatcher.on('file-added', () => void handleMirrorChange());
 
-        // Periodic refresh for new vault files
+        // Periodic bidirectional sync
         mirrorInterval = setInterval(async () => {
           try {
             await mirrorAdapter.syncBack(targetPath);
-            await mirrorAdapter.refreshSymlinks(targetPath);
+            await mirrorAdapter.syncFromVault(targetPath);
           } catch {
             // Non-critical
           }
@@ -214,7 +214,7 @@ const startCommand = new Command('start')
           console.log(chalk.dim(`  OpenClaw: ${backed.synced.length} file${backed.synced.length === 1 ? '' : 's'} synced back`));
         }
 
-        // Watch OpenClaw workspace for broken symlinks
+        // Watch OpenClaw workspace for changes
         openclawWatcher = new FileWatcher(workspacePath, config.sync.debounceMs);
         openclawWatcher.start();
 
@@ -234,6 +234,7 @@ const startCommand = new Command('start')
         openclawInterval = setInterval(async () => {
           try {
             await openclawAdapter.syncBack(workspacePath);
+            await openclawAdapter.syncFromVault(workspacePath);
           } catch {
             // Non-critical
           }
@@ -257,7 +258,7 @@ const startCommand = new Command('start')
           console.log(chalk.dim(`  Claude: ${backed.synced.length} file${backed.synced.length === 1 ? '' : 's'} synced back`));
         }
 
-        // Watch Claude directory for broken symlinks
+        // Watch Claude directory for changes
         claudeWatcher = new FileWatcher(claudeDir, config.sync.debounceMs);
         claudeWatcher.start();
 
@@ -277,6 +278,7 @@ const startCommand = new Command('start')
         claudeInterval = setInterval(async () => {
           try {
             await claudeAdapter.syncBack(claudeDir);
+            await claudeAdapter.syncFromVault(claudeDir);
           } catch {
             // Non-critical
           }

--- a/src/cli/reset.ts
+++ b/src/cli/reset.ts
@@ -37,7 +37,7 @@ export const resetCommand = new Command('reset')
       console.log(chalk.bold.red('ContextMate Reset'));
       console.log('');
       console.log('This will:');
-      console.log(`  - Remove all adapter symlinks (Claude Code, OpenClaw)`);
+      console.log(`  - Disconnect all adapters (Claude Code, OpenClaw)`);
 
       // Show userId if registered
       let userId: string | null = null;
@@ -75,21 +75,21 @@ export const resetCommand = new Command('reset')
       };
 
       try {
-        console.log(chalk.dim('Removing Claude Code symlinks...'));
+        console.log(chalk.dim('Disconnecting Claude Code adapter...'));
         const adapter = getAdapter('claude', adapterOpts);
-        await adapter.removeSymlinks(config.adapters.claude.claudeDir);
-        console.log(chalk.green('  Claude Code symlinks removed.'));
+        await adapter.disconnect(config.adapters.claude.claudeDir);
+        console.log(chalk.green('  Claude Code adapter disconnected.'));
       } catch (err) {
-        console.log(chalk.yellow(`  Warning: Could not remove Claude symlinks (${err instanceof Error ? err.message : String(err)})`));
+        console.log(chalk.yellow(`  Warning: Could not disconnect Claude adapter (${err instanceof Error ? err.message : String(err)})`));
       }
 
       try {
-        console.log(chalk.dim('Removing OpenClaw symlinks...'));
+        console.log(chalk.dim('Disconnecting OpenClaw adapter...'));
         const adapter = getAdapter('openclaw', adapterOpts);
-        await adapter.removeSymlinks(config.adapters.openclaw.workspacePath);
-        console.log(chalk.green('  OpenClaw symlinks removed.'));
+        await adapter.disconnect(config.adapters.openclaw.workspacePath);
+        console.log(chalk.green('  OpenClaw adapter disconnected.'));
       } catch (err) {
-        console.log(chalk.yellow(`  Warning: Could not remove OpenClaw symlinks (${err instanceof Error ? err.message : String(err)})`));
+        console.log(chalk.yellow(`  Warning: Could not disconnect OpenClaw adapter (${err instanceof Error ? err.message : String(err)})`));
       }
 
       // 2. Delete the entire ~/.contextmate directory

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -475,10 +475,10 @@ export const setupCommand = new Command('setup')
           `${chalk.dim(`${importResult.skipped.length} unchanged`)}`,
         );
 
-        // Create symlinks
-        console.log(chalk.dim('    Creating symlinks...'));
-        const symlinkResult = await adapter.createSymlinks(claudeDir);
-        console.log(`    ${chalk.green(`${symlinkResult.created.length} symlinks`)}`);
+        // Copy files to workspace
+        console.log(chalk.dim('    Syncing to workspace...'));
+        const copyResult = await adapter.copyToWorkspace(claudeDir);
+        console.log(`    ${chalk.green(`${copyResult.copied.length} files synced`)}`);
 
         config!.adapters.claude.enabled = true;
         config!.adapters.claude.claudeDir = claudeDir;
@@ -514,9 +514,9 @@ export const setupCommand = new Command('setup')
           `${chalk.dim(`${importResult.skipped.length} unchanged`)}`,
         );
 
-        console.log(chalk.dim('    Creating symlinks...'));
-        const symlinkResult = await adapter.createSymlinks(openclawDir);
-        console.log(`    ${chalk.green(`${symlinkResult.created.length} symlinks`)}`);
+        console.log(chalk.dim('    Syncing to workspace...'));
+        const copyResult = await adapter.copyToWorkspace(openclawDir);
+        console.log(`    ${chalk.green(`${copyResult.copied.length} files synced`)}`);
 
         config!.adapters.openclaw.enabled = true;
         config!.adapters.openclaw.workspacePath = openclawDir;
@@ -566,10 +566,10 @@ export const setupCommand = new Command('setup')
               console.log(`    ${chalk.green(`${importResult.imported.length} files imported to vault`)}`);
             }
 
-            // Create symlinks from target -> vault
-            console.log(chalk.dim('    Creating symlinks...'));
-            const symlinkResult = await mirrorAdapter.createSymlinks(resolved);
-            console.log(`    ${chalk.green(`${symlinkResult.created.length} symlinks`)}`);
+            // Copy files to target
+            console.log(chalk.dim('    Syncing to target...'));
+            const copyResult = await mirrorAdapter.copyToWorkspace(resolved);
+            console.log(`    ${chalk.green(`${copyResult.copied.length} files synced`)}`);
 
             config!.adapters.mirror.enabled = true;
             config!.adapters.mirror.targetPath = resolved;
@@ -764,9 +764,9 @@ export const setupCommand = new Command('setup')
         const targetPath = config!.adapters.mirror.targetPath;
 
         await mirrorAdapter.syncBack(targetPath);
-        const initial = await mirrorAdapter.refreshSymlinks(targetPath);
-        if (initial.created.length > 0) {
-          console.log(chalk.dim(`  Mirror: ${initial.created.length} new symlinks`));
+        const initial = await mirrorAdapter.refreshCopies(targetPath);
+        if (initial.copied.length > 0) {
+          console.log(chalk.dim(`  Mirror: ${initial.copied.length} files synced`));
         }
 
         mirrorWatcher = new FileWatcher(targetPath, config!.sync.debounceMs);
@@ -785,7 +785,7 @@ export const setupCommand = new Command('setup')
         mirrorInterval = setInterval(async () => {
           try {
             await mirrorAdapter.syncBack(targetPath);
-            await mirrorAdapter.refreshSymlinks(targetPath);
+            await mirrorAdapter.syncFromVault(targetPath);
           } catch {
             // Non-critical
           }
@@ -824,6 +824,7 @@ export const setupCommand = new Command('setup')
         openclawInterval = setInterval(async () => {
           try {
             await openclawAdapter.syncBack(workspacePath);
+            await openclawAdapter.syncFromVault(workspacePath);
           } catch {
             // Non-critical
           }
@@ -861,6 +862,7 @@ export const setupCommand = new Command('setup')
         claudeInterval = setInterval(async () => {
           try {
             await claudeAdapter.syncBack(claudeDir);
+            await claudeAdapter.syncFromVault(claudeDir);
           } catch {
             // Non-critical
           }

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -41,7 +41,7 @@ export class SyncEngine {
     this.stateDb = new SyncStateDB(dbPath);
 
     // Start file watcher
-    this.watcher = new FileWatcher(this.config.vault.path, this.config.sync.debounceMs, { followSymlinks: true });
+    this.watcher = new FileWatcher(this.config.vault.path, this.config.sync.debounceMs);
     this.watcher.start();
 
     // Wire up local file events BEFORE syncAll so no events are lost

--- a/tests/adapters/claude.test.ts
+++ b/tests/adapters/claude.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { ClaudeCodeAdapter } from '../../src/adapters/claude.js';
 import { tmpdir } from 'node:os';
-import { mkdtemp, rm, writeFile, mkdir, readFile, lstat, readdir, unlink } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, readFile, lstat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 let tmpDir: string;
@@ -73,13 +73,11 @@ afterEach(async () => {
 describe('ClaudeCodeAdapter', () => {
   describe('detect()', () => {
     it('returns path when .claude directory exists', async () => {
-      // detect() checks the real ~/.claude, so we just verify the interface
       const result = await adapter.detect();
       expect(result === null || typeof result === 'string').toBe(true);
     });
 
     it('returns null when .claude does not exist', async () => {
-      // We can't easily test this without mocking homedir, but we verify the type
       const result = await adapter.detect();
       expect(result === null || typeof result === 'string').toBe(true);
     });
@@ -87,17 +85,9 @@ describe('ClaudeCodeAdapter', () => {
 
   describe('import()', () => {
     it('copies skills to vault/skills/', async () => {
-      // We need to override the homedir-based skill lookup.
-      // The adapter uses homedir() internally for skills, so we manually
-      // populate the vault/skills/ by directly importing with a patched approach.
-      // Instead, test by importing from claudeDir which handles rules/CLAUDE.md/projects.
-      // Skills need ~/.agents/skills which is hardcoded to homedir. For a proper
-      // unit test we test the full import and check non-skill items.
-
       const result = await adapter.import(claudeDir);
       expect(result.errors.length).toBe(0);
 
-      // Check rules were imported
       const ruleContent = await readFile(
         join(vaultPath, 'claude', 'rules', 'coding-standards.md'),
         'utf-8',
@@ -150,13 +140,11 @@ describe('ClaudeCodeAdapter', () => {
       await adapter.import(claudeDir);
       const result = await adapter.import(claudeDir);
       expect(result.skipped.length).toBeGreaterThan(0);
-      // Rules + CLAUDE.md + project memories = at least 5 skipped
       expect(result.skipped).toContain('claude/CLAUDE.md');
       expect(result.imported.length).toBe(0);
     });
 
     it('handles missing optional directories gracefully', async () => {
-      // Create a minimal .claude with just CLAUDE.md
       const minDir = join(tmpDir, 'minimal-claude');
       await mkdir(minDir, { recursive: true });
       await writeFile(join(minDir, 'CLAUDE.md'), '# Minimal');
@@ -164,188 +152,141 @@ describe('ClaudeCodeAdapter', () => {
       const result = await adapter.import(minDir);
       expect(result.errors.length).toBe(0);
       expect(result.imported).toContain('claude/CLAUDE.md');
-      // No rules or projects imported since dirs don't exist
       const rules = result.imported.filter((i) => i.startsWith('claude/rules/'));
       expect(rules.length).toBe(0);
     });
   });
 
-  describe('createSymlinks()', () => {
-    it('creates correct symlinks for rules', async () => {
+  describe('copyToWorkspace()', () => {
+    it('copies rules as regular files', async () => {
       await adapter.import(claudeDir);
-      const result = await adapter.createSymlinks(claudeDir);
-      // Filter out skill-related errors (skills use hardcoded homedir)
+      const result = await adapter.copyToWorkspace(claudeDir);
       const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
       expect(nonSkillErrors.length).toBe(0);
-
-      // Check rule symlinks
-      const ruleLink = join(claudeDir, 'rules', 'coding-standards.md');
-      const stats = await lstat(ruleLink);
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      const content = await readFile(ruleLink, 'utf-8');
-      expect(content).toContain('Use TypeScript strict mode');
-    });
-
-    it('creates correct symlink for CLAUDE.md', async () => {
-      await adapter.import(claudeDir);
-      const result = await adapter.createSymlinks(claudeDir);
-      const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
-      expect(nonSkillErrors.length).toBe(0);
-      expect(result.created).toContain('CLAUDE.md');
-
-      const claudeMdLink = join(claudeDir, 'CLAUDE.md');
-      const stats = await lstat(claudeMdLink);
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      const content = await readFile(claudeMdLink, 'utf-8');
-      expect(content).toContain('Global instructions for Claude');
-    });
-
-    it('creates correct symlinks for project memories', async () => {
-      await adapter.import(claudeDir);
-      const result = await adapter.createSymlinks(claudeDir);
-      const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
-      expect(nonSkillErrors.length).toBe(0);
-
-      const memLink = join(claudeDir, 'projects', 'my-project', 'memory', 'MEMORY.md');
-      const stats = await lstat(memLink);
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      const content = await readFile(memLink, 'utf-8');
-      expect(content).toContain('Key architecture decisions');
-    });
-
-    it('creates symlinks for all file types', async () => {
-      await adapter.import(claudeDir);
-      const result = await adapter.createSymlinks(claudeDir);
-      const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
-      expect(nonSkillErrors.length).toBe(0);
-
-      // Should have: 2 rules + 1 CLAUDE.md + 2 project memories = 5
-      // (skills are skipped because they use homedir-based path)
-      const ruleLinks = result.created.filter((c) => c.startsWith('rules/'));
-      const projectLinks = result.created.filter((c) => c.startsWith('project:'));
-      expect(ruleLinks.length).toBe(2);
-      expect(result.created).toContain('CLAUDE.md');
-      expect(projectLinks.length).toBe(2);
-    });
-  });
-
-  describe('verifySymlinks()', () => {
-    it('validates all symlinks as valid after creation', async () => {
-      await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
-
-      const result = await adapter.verifySymlinks(claudeDir);
-      // Filter out skill-related entries (skills use hardcoded homedir)
-      const nonSkillValid = result.valid.filter((v) => !v.startsWith('skill:'));
-      const nonSkillBroken = result.broken.filter((v) => !v.startsWith('skill:'));
-      expect(nonSkillValid.length).toBeGreaterThan(0);
-      expect(nonSkillBroken.length).toBe(0);
-
-      // Should include rules, CLAUDE.md, and project memories
-      expect(result.valid).toContain('CLAUDE.md');
-      const ruleValid = result.valid.filter((v) => v.startsWith('rules/'));
-      expect(ruleValid.length).toBe(2);
-    });
-  });
-
-  describe('removeSymlinks()', () => {
-    it('restores originals after removing symlinks', async () => {
-      await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
-
-      // Verify CLAUDE.md is a symlink
-      let stats = await lstat(join(claudeDir, 'CLAUDE.md'));
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      // Remove symlinks
-      await adapter.removeSymlinks(claudeDir);
-
-      // CLAUDE.md should now be a regular file
-      stats = await lstat(join(claudeDir, 'CLAUDE.md'));
-      expect(stats.isSymbolicLink()).toBe(false);
-      expect(stats.isFile()).toBe(true);
-
-      const content = await readFile(join(claudeDir, 'CLAUDE.md'), 'utf-8');
-      expect(content).toContain('Global instructions for Claude');
-    });
-
-    it('restores rule files after removing symlinks', async () => {
-      await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
 
       const rulePath = join(claudeDir, 'rules', 'coding-standards.md');
-      let stats = await lstat(rulePath);
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      await adapter.removeSymlinks(claudeDir);
-
-      stats = await lstat(rulePath);
-      expect(stats.isSymbolicLink()).toBe(false);
+      const stats = await lstat(rulePath);
       expect(stats.isFile()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
 
       const content = await readFile(rulePath, 'utf-8');
       expect(content).toContain('Use TypeScript strict mode');
     });
 
-    it('restores project memory files after removing symlinks', async () => {
+    it('copies CLAUDE.md as a regular file', async () => {
       await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
+      // Modify vault content to simulate a remote update
+      await writeFile(join(vaultPath, 'claude', 'CLAUDE.md'), '# Updated\nNew cloud content');
+      const result = await adapter.copyToWorkspace(claudeDir);
+      const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
+      expect(nonSkillErrors.length).toBe(0);
+      expect(result.copied).toContain('CLAUDE.md');
+
+      const claudeMdPath = join(claudeDir, 'CLAUDE.md');
+      const stats = await lstat(claudeMdPath);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
+
+      const content = await readFile(claudeMdPath, 'utf-8');
+      expect(content).toContain('New cloud content');
+    });
+
+    it('copies project memories as regular files', async () => {
+      await adapter.import(claudeDir);
+      const result = await adapter.copyToWorkspace(claudeDir);
+      const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
+      expect(nonSkillErrors.length).toBe(0);
 
       const memPath = join(claudeDir, 'projects', 'my-project', 'memory', 'MEMORY.md');
-      let stats = await lstat(memPath);
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      await adapter.removeSymlinks(claudeDir);
-
-      stats = await lstat(memPath);
-      expect(stats.isSymbolicLink()).toBe(false);
+      const stats = await lstat(memPath);
       expect(stats.isFile()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
 
       const content = await readFile(memPath, 'utf-8');
       expect(content).toContain('Key architecture decisions');
     });
+
+    it('copies all file types when vault has newer content', async () => {
+      await adapter.import(claudeDir);
+      // Modify vault files to simulate remote updates
+      await writeFile(join(vaultPath, 'claude', 'CLAUDE.md'), '# Updated CLAUDE');
+      await writeFile(join(vaultPath, 'claude', 'rules', 'coding-standards.md'), '# Updated rule 1');
+      await writeFile(join(vaultPath, 'claude', 'rules', 'review-process.md'), '# Updated rule 2');
+      await writeFile(join(vaultPath, 'claude', 'projects', 'my-project', 'memory', 'MEMORY.md'), '# Updated mem 1');
+      await writeFile(join(vaultPath, 'claude', 'projects', 'my-project', 'memory', 'debug-notes.md'), '# Updated mem 2');
+
+      const result = await adapter.copyToWorkspace(claudeDir);
+      const nonSkillErrors = result.errors.filter((e) => !e.startsWith('skill '));
+      expect(nonSkillErrors.length).toBe(0);
+
+      // Should have: 2 rules + 1 CLAUDE.md + 2 project memories = 5
+      const ruleCopied = result.copied.filter((c) => c.startsWith('rules/'));
+      const projectCopied = result.copied.filter((c) => c.startsWith('project:'));
+      expect(ruleCopied.length).toBe(2);
+      expect(result.copied).toContain('CLAUDE.md');
+      expect(projectCopied.length).toBe(2);
+    });
+  });
+
+  describe('verifySync()', () => {
+    it('validates all files as synced after copy', async () => {
+      await adapter.import(claudeDir);
+      await adapter.copyToWorkspace(claudeDir);
+
+      const result = await adapter.verifySync(claudeDir);
+      const nonSkillSynced = result.synced.filter((v) => !v.startsWith('skill:'));
+      const nonSkillStale = result.stale.filter((v) => !v.startsWith('skill:'));
+      expect(nonSkillSynced.length).toBeGreaterThan(0);
+      expect(nonSkillStale.length).toBe(0);
+
+      expect(result.synced).toContain('CLAUDE.md');
+      const ruleSynced = result.synced.filter((v) => v.startsWith('rules/'));
+      expect(ruleSynced.length).toBe(2);
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('leaves workspace files intact', async () => {
+      await adapter.import(claudeDir);
+      await adapter.copyToWorkspace(claudeDir);
+
+      await adapter.disconnect(claudeDir);
+
+      // Files should still be readable
+      const content = await readFile(join(claudeDir, 'CLAUDE.md'), 'utf-8');
+      expect(content).toContain('Global instructions for Claude');
+
+      const ruleContent = await readFile(join(claudeDir, 'rules', 'coding-standards.md'), 'utf-8');
+      expect(ruleContent).toContain('Use TypeScript strict mode');
+    });
   });
 
   describe('syncBack()', () => {
-    it('detects broken rule symlinks and syncs content back to vault', async () => {
+    it('detects changed rules and syncs content to vault', async () => {
       await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
 
       const rulePath = join(claudeDir, 'rules', 'coding-standards.md');
-      let stats = await lstat(rulePath);
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      // Simulate editor atomic save: delete symlink and write regular file
-      await unlink(rulePath);
       await writeFile(rulePath, '# Coding Standards\nUpdated standards');
-
-      stats = await lstat(rulePath);
-      expect(stats.isSymbolicLink()).toBe(false);
 
       const result = await adapter.syncBack(claudeDir);
       expect(result.synced).toContain('claude/rules/coding-standards.md');
 
-      // Vault should have new content
       const vaultContent = await readFile(
         join(vaultPath, 'claude', 'rules', 'coding-standards.md'),
         'utf-8',
       );
       expect(vaultContent).toContain('Updated standards');
 
-      // File should be a symlink again
-      stats = await lstat(rulePath);
-      expect(stats.isSymbolicLink()).toBe(true);
+      // File should still be a regular file
+      const stats = await lstat(rulePath);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
     });
 
-    it('detects broken CLAUDE.md symlink and syncs back', async () => {
+    it('detects changed CLAUDE.md and syncs back', async () => {
       await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
 
       const claudeMdPath = join(claudeDir, 'CLAUDE.md');
-      await unlink(claudeMdPath);
       await writeFile(claudeMdPath, '# Updated CLAUDE.md\nNew instructions');
 
       const result = await adapter.syncBack(claudeDir);
@@ -353,17 +294,12 @@ describe('ClaudeCodeAdapter', () => {
 
       const vaultContent = await readFile(join(vaultPath, 'claude', 'CLAUDE.md'), 'utf-8');
       expect(vaultContent).toContain('New instructions');
-
-      const stats = await lstat(claudeMdPath);
-      expect(stats.isSymbolicLink()).toBe(true);
     });
 
-    it('detects broken project memory symlinks and syncs back', async () => {
+    it('detects changed project memory and syncs back', async () => {
       await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
 
       const memPath = join(claudeDir, 'projects', 'my-project', 'memory', 'MEMORY.md');
-      await unlink(memPath);
       await writeFile(memPath, '# Project Memory\nUpdated architecture notes');
 
       const result = await adapter.syncBack(claudeDir);
@@ -374,33 +310,50 @@ describe('ClaudeCodeAdapter', () => {
         'utf-8',
       );
       expect(vaultContent).toContain('Updated architecture notes');
-
-      const stats = await lstat(memPath);
-      expect(stats.isSymbolicLink()).toBe(true);
     });
 
-    it('skips files that are still valid symlinks', async () => {
+    it('skips files with identical content', async () => {
       await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
 
       const result = await adapter.syncBack(claudeDir);
       expect(result.synced.length).toBe(0);
     });
+  });
 
-    it('re-creates symlink when content is identical', async () => {
+  describe('syncFromVault()', () => {
+    it('copies vault changes to workspace', async () => {
       await adapter.import(claudeDir);
-      await adapter.createSymlinks(claudeDir);
 
-      const rulePath = join(claudeDir, 'rules', 'coding-standards.md');
-      const originalContent = await readFile(rulePath, 'utf-8');
-      await unlink(rulePath);
-      await writeFile(rulePath, originalContent);
+      // Simulate a remote change arriving in the vault
+      await writeFile(join(vaultPath, 'claude', 'CLAUDE.md'), '# Updated from cloud');
 
-      const result = await adapter.syncBack(claudeDir);
+      const result = await adapter.syncFromVault(claudeDir);
+      expect(result.synced).toContain('CLAUDE.md');
+
+      const content = await readFile(join(claudeDir, 'CLAUDE.md'), 'utf-8');
+      expect(content).toContain('Updated from cloud');
+    });
+
+    it('copies vault rule changes to workspace', async () => {
+      await adapter.import(claudeDir);
+
+      await writeFile(
+        join(vaultPath, 'claude', 'rules', 'coding-standards.md'),
+        '# Updated Standards\nFrom another device',
+      );
+
+      const result = await adapter.syncFromVault(claudeDir);
+      expect(result.synced).toContain('rules/coding-standards.md');
+
+      const content = await readFile(join(claudeDir, 'rules', 'coding-standards.md'), 'utf-8');
+      expect(content).toContain('From another device');
+    });
+
+    it('skips files already in sync', async () => {
+      await adapter.import(claudeDir);
+
+      const result = await adapter.syncFromVault(claudeDir);
       expect(result.synced.length).toBe(0);
-
-      const stats = await lstat(rulePath);
-      expect(stats.isSymbolicLink()).toBe(true);
     });
   });
 });

--- a/tests/adapters/mirror.test.ts
+++ b/tests/adapters/mirror.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { MirrorAdapter } from '../../src/adapters/mirror.js';
 import { tmpdir } from 'node:os';
-import { mkdtemp, rm, writeFile, mkdir, readFile, lstat, unlink, symlink } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, readFile, lstat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 let tmpDir: string;
@@ -39,23 +39,24 @@ describe('MirrorAdapter', () => {
     expect(result).toBeNull();
   });
 
-  it('createSymlinks() symlinks all vault files when no include filter', async () => {
+  it('copyToWorkspace() copies all vault files as regular files when no include filter', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    const result = await adapter.createSymlinks(targetPath);
+    const result = await adapter.copyToWorkspace(targetPath);
     expect(result.errors.length).toBe(0);
-    expect(result.created.length).toBe(4);
+    expect(result.copied.length).toBe(4);
 
-    // Verify symlinks exist and are readable
+    // Verify files are regular files (not symlinks) and readable
     const stats = await lstat(join(targetPath, 'openclaw', 'MEMORY.md'));
-    expect(stats.isSymbolicLink()).toBe(true);
+    expect(stats.isFile()).toBe(true);
+    expect(stats.isSymbolicLink()).toBe(false);
 
     const content = await readFile(join(targetPath, 'openclaw', 'MEMORY.md'), 'utf-8');
     expect(content).toContain('Agent memory content');
   });
 
-  it('createSymlinks() only symlinks files matching include patterns', async () => {
+  it('copyToWorkspace() only copies files matching include patterns', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({
       vaultPath,
@@ -63,10 +64,10 @@ describe('MirrorAdapter', () => {
       include: ['openclaw/**'],
     });
 
-    const result = await adapter.createSymlinks(targetPath);
+    const result = await adapter.copyToWorkspace(targetPath);
     expect(result.errors.length).toBe(0);
     // Only openclaw/ files (3), not skills/ (1)
-    expect(result.created.length).toBe(3);
+    expect(result.copied.length).toBe(3);
 
     // skills/ should not be present
     let hasSkill = false;
@@ -80,7 +81,6 @@ describe('MirrorAdapter', () => {
   });
 
   it('import() copies existing files from target to vault', async () => {
-    // Put files in target directory
     await writeFile(join(targetPath, 'README.md'), '# Readme');
     await mkdir(join(targetPath, 'docs'), { recursive: true });
     await writeFile(join(targetPath, 'docs', 'guide.md'), '# Guide');
@@ -91,7 +91,6 @@ describe('MirrorAdapter', () => {
     expect(result.errors.length).toBe(0);
     expect(result.imported.length).toBe(2);
 
-    // Verify files were copied to vault root (no prefix)
     const content = await readFile(join(vaultPath, 'README.md'), 'utf-8');
     expect(content).toBe('# Readme');
 
@@ -100,7 +99,6 @@ describe('MirrorAdapter', () => {
   });
 
   it('import() respects include filters', async () => {
-    // Put files in target directory
     await mkdir(join(targetPath, 'openclaw'), { recursive: true });
     await writeFile(join(targetPath, 'openclaw', 'MEMORY.md'), '# Memory');
     await writeFile(join(targetPath, 'unrelated.txt'), 'should be excluded');
@@ -113,16 +111,12 @@ describe('MirrorAdapter', () => {
     const result = await adapter.import(targetPath);
 
     expect(result.imported).toContain(join('openclaw', 'MEMORY.md'));
-    // unrelated.txt should NOT have been imported
     const importedPaths = [...result.imported, ...result.skipped];
     expect(importedPaths).not.toContain('unrelated.txt');
   });
 
   it('import() skips identical content', async () => {
-    // Pre-populate vault
     await writeFile(join(vaultPath, 'README.md'), '# Readme');
-
-    // Put same content in target
     await writeFile(join(targetPath, 'README.md'), '# Readme');
 
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
@@ -132,54 +126,43 @@ describe('MirrorAdapter', () => {
     expect(result.skipped.length).toBe(1);
   });
 
-  it('verifySymlinks() identifies valid and broken symlinks', async () => {
+  it('verifySync() identifies synced and stale files', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    await adapter.createSymlinks(targetPath);
-    const result = await adapter.verifySymlinks(targetPath);
+    await adapter.copyToWorkspace(targetPath);
+    const result = await adapter.verifySync(targetPath);
 
-    expect(result.valid.length).toBe(4);
-    expect(result.broken.length).toBe(0);
+    expect(result.synced.length).toBe(4);
+    expect(result.stale.length).toBe(0);
   });
 
-  it('removeSymlinks() restores files from vault copies', async () => {
+  it('disconnect() leaves workspace files intact', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    await adapter.createSymlinks(targetPath);
-
-    // Verify it's a symlink
-    let stats = await lstat(join(targetPath, 'openclaw', 'MEMORY.md'));
-    expect(stats.isSymbolicLink()).toBe(true);
-
-    await adapter.removeSymlinks(targetPath);
-
-    // Should now be a regular file (restored from vault copy)
-    stats = await lstat(join(targetPath, 'openclaw', 'MEMORY.md'));
-    expect(stats.isSymbolicLink()).toBe(false);
-    expect(stats.isFile()).toBe(true);
+    await adapter.copyToWorkspace(targetPath);
+    await adapter.disconnect(targetPath);
 
     const content = await readFile(join(targetPath, 'openclaw', 'MEMORY.md'), 'utf-8');
     expect(content).toContain('Agent memory content');
   });
 
-  it('refreshSymlinks() only creates missing symlinks', async () => {
+  it('refreshCopies() only copies new or stale files', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    // Create initial symlinks
-    await adapter.createSymlinks(targetPath);
+    // Initial copy
+    await adapter.copyToWorkspace(targetPath);
 
     // Add a new file to vault
     await writeFile(join(vaultPath, 'openclaw', 'HEARTBEAT.md'), '# Heartbeat');
 
-    // Refresh should only create the new one
-    const result = await adapter.refreshSymlinks(targetPath);
-    expect(result.created.length).toBe(1);
-    expect(result.created[0]).toBe(join('openclaw', 'HEARTBEAT.md'));
+    // Refresh should only copy the new one
+    const result = await adapter.refreshCopies(targetPath);
+    expect(result.copied.length).toBe(1);
+    expect(result.copied[0]).toBe(join('openclaw', 'HEARTBEAT.md'));
 
-    // Verify the new symlink works
     const content = await readFile(join(targetPath, 'openclaw', 'HEARTBEAT.md'), 'utf-8');
     expect(content).toContain('Heartbeat');
   });
@@ -189,24 +172,22 @@ describe('MirrorAdapter', () => {
     const badTarget = join(vaultPath, 'mirror-output');
     await mkdir(badTarget, { recursive: true });
 
-    await expect(adapter.createSymlinks(badTarget)).rejects.toThrow(
+    await expect(adapter.copyToWorkspace(badTarget)).rejects.toThrow(
       'Mirror target cannot be inside the vault',
     );
   });
 
-  it('syncBack() detects broken symlinks and copies content to vault', async () => {
+  it('syncBack() detects workspace changes and copies content to vault', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    // Create symlinks
-    await adapter.createSymlinks(targetPath);
+    // Copy files to target
+    await adapter.copyToWorkspace(targetPath);
 
-    // Simulate editor atomic save: replace symlink with regular file
+    // Edit a file in the target
     const filePath = join(targetPath, 'openclaw', 'MEMORY.md');
-    await unlink(filePath);
     await writeFile(filePath, '# Updated Memory\nEdited by user');
 
-    // syncBack should detect the broken symlink and copy to vault
     const result = await adapter.syncBack(targetPath);
     expect(result.synced.length).toBe(1);
     expect(result.synced[0]).toBe(join('openclaw', 'MEMORY.md'));
@@ -215,52 +196,47 @@ describe('MirrorAdapter', () => {
     const vaultContent = await readFile(join(vaultPath, 'openclaw', 'MEMORY.md'), 'utf-8');
     expect(vaultContent).toBe('# Updated Memory\nEdited by user');
 
-    // Target file should be a symlink again
+    // Target file should still be a regular file
     const stats = await lstat(filePath);
-    expect(stats.isSymbolicLink()).toBe(true);
+    expect(stats.isFile()).toBe(true);
+    expect(stats.isSymbolicLink()).toBe(false);
   });
 
-  it('syncBack() re-creates symlink without syncing when content is identical', async () => {
+  it('syncBack() skips files with identical content', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    await adapter.createSymlinks(targetPath);
+    await adapter.copyToWorkspace(targetPath);
 
-    // Replace symlink with regular file containing same content
-    const filePath = join(targetPath, 'openclaw', 'MEMORY.md');
-    const originalContent = await readFile(filePath, 'utf-8');
-    await unlink(filePath);
-    await writeFile(filePath, originalContent);
-
-    // syncBack should NOT report it as synced (content unchanged)
+    // No changes — all files identical
     const result = await adapter.syncBack(targetPath);
     expect(result.synced.length).toBe(0);
-
-    // But the symlink should be restored
-    const stats = await lstat(filePath);
-    expect(stats.isSymbolicLink()).toBe(true);
   });
 
-  it('syncBack() ignores files that are still valid symlinks', async () => {
+  it('syncFromVault() copies vault changes to target', async () => {
     await createMockVault(vaultPath);
     const adapter = new MirrorAdapter({ vaultPath, backupsPath });
 
-    await adapter.createSymlinks(targetPath);
+    await adapter.copyToWorkspace(targetPath);
 
-    // No changes — all symlinks intact
-    const result = await adapter.syncBack(targetPath);
-    expect(result.synced.length).toBe(0);
+    // Simulate a remote change arriving in the vault
+    await writeFile(join(vaultPath, 'openclaw', 'MEMORY.md'), '# Memory\nUpdated from cloud');
+
+    const result = await adapter.syncFromVault(targetPath);
+    expect(result.synced.length).toBe(1);
+
+    const content = await readFile(join(targetPath, 'openclaw', 'MEMORY.md'), 'utf-8');
+    expect(content).toContain('Updated from cloud');
   });
 
   it('throws error when vault is inside target', async () => {
-    // Create adapter where vault is inside target
     const outerTarget = tmpDir;
     const adapter = new MirrorAdapter({
       vaultPath: join(outerTarget, 'vault'),
       backupsPath,
     });
 
-    await expect(adapter.createSymlinks(outerTarget)).rejects.toThrow(
+    await expect(adapter.copyToWorkspace(outerTarget)).rejects.toThrow(
       'Mirror target cannot be inside the vault',
     );
   });

--- a/tests/adapters/openclaw.test.ts
+++ b/tests/adapters/openclaw.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { OpenClawAdapter } from '../../src/adapters/openclaw.js';
 import { tmpdir } from 'node:os';
-import { mkdtemp, rm, writeFile, mkdir, readFile, lstat, unlink } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile, mkdir, readFile, lstat } from 'node:fs/promises';
 import { join } from 'node:path';
 
 let tmpDir: string;
@@ -38,12 +38,7 @@ afterEach(async () => {
 
 describe('OpenClawAdapter', () => {
   it('detect() returns null when workspace does not exist', async () => {
-    // detect() looks for ~/.openclaw/workspace which is not our tmpDir
-    // So by default it should return null (unless the user has one)
-    // We test with a known non-existent path by creating a fresh adapter
     const result = await adapter.detect();
-    // This tests the actual default path. If it exists on this machine,
-    // it would return a path. For a clean test, we just verify it returns string|null.
     expect(result === null || typeof result === 'string').toBe(true);
   });
 
@@ -52,7 +47,6 @@ describe('OpenClawAdapter', () => {
     expect(result.errors.length).toBe(0);
     expect(result.imported.length).toBeGreaterThan(0);
 
-    // Check that files were copied to vault under openclaw/ prefix
     const memoryContent = await readFile(join(vaultPath, 'openclaw', 'MEMORY.md'), 'utf-8');
     expect(memoryContent).toContain('Test memory content');
 
@@ -64,7 +58,6 @@ describe('OpenClawAdapter', () => {
   });
 
   it('import() handles missing optional files gracefully', async () => {
-    // Create a minimal workspace with only MEMORY.md (no IDENTITY, no skills, no memory dir)
     const minimalWs = join(tmpDir, 'minimal-workspace');
     await mkdir(minimalWs, { recursive: true });
     await writeFile(join(minimalWs, 'MEMORY.md'), '# Minimal');
@@ -76,65 +69,45 @@ describe('OpenClawAdapter', () => {
   });
 
   it('import() skips files with identical content', async () => {
-    // First import
     await adapter.import(workspacePath);
-    // Second import -- same content should be skipped
     const result = await adapter.import(workspacePath);
     expect(result.skipped.length).toBeGreaterThan(0);
     expect(result.imported.length).toBe(0);
   });
 
-  it('createSymlinks() creates working symlinks', async () => {
-    // First import files to vault
+  it('copyToWorkspace() copies vault files to workspace as regular files', async () => {
     await adapter.import(workspacePath);
-
-    const result = await adapter.createSymlinks(workspacePath);
+    const result = await adapter.copyToWorkspace(workspacePath);
     expect(result.errors.length).toBe(0);
-    expect(result.created.length).toBeGreaterThan(0);
 
-    // Check MEMORY.md is now a symlink
+    // Files should be regular files (not symlinks)
     const stats = await lstat(join(workspacePath, 'MEMORY.md'));
-    expect(stats.isSymbolicLink()).toBe(true);
+    expect(stats.isFile()).toBe(true);
+    expect(stats.isSymbolicLink()).toBe(false);
 
-    // The symlink should still be readable
     const content = await readFile(join(workspacePath, 'MEMORY.md'), 'utf-8');
     expect(content).toContain('Test memory content');
   });
 
-  it('verifySymlinks() identifies valid and broken symlinks', async () => {
-    // Import and create symlinks
+  it('verifySync() identifies synced and stale files', async () => {
     await adapter.import(workspacePath);
-    await adapter.createSymlinks(workspacePath);
-
-    const result = await adapter.verifySymlinks(workspacePath);
-    expect(result.valid.length).toBeGreaterThan(0);
-    expect(result.broken.length).toBe(0);
+    // Workspace and vault should be in sync after import (same content)
+    const result = await adapter.verifySync(workspacePath);
+    expect(result.synced.length).toBeGreaterThan(0);
+    expect(result.stale.length).toBe(0);
   });
 
-  it('removeSymlinks() restores original files', async () => {
-    // Import and create symlinks
+  it('disconnect() leaves workspace files intact', async () => {
     await adapter.import(workspacePath);
-    await adapter.createSymlinks(workspacePath);
+    await adapter.copyToWorkspace(workspacePath);
+    await adapter.disconnect(workspacePath);
 
-    // Verify MEMORY.md is a symlink
-    let stats = await lstat(join(workspacePath, 'MEMORY.md'));
-    expect(stats.isSymbolicLink()).toBe(true);
-
-    // Remove symlinks
-    await adapter.removeSymlinks(workspacePath);
-
-    // MEMORY.md should now be a regular file (restored from backup or vault copy)
-    stats = await lstat(join(workspacePath, 'MEMORY.md'));
-    expect(stats.isSymbolicLink()).toBe(false);
-    expect(stats.isFile()).toBe(true);
-
-    // Content should still be readable
+    // Files should still be readable
     const content = await readFile(join(workspacePath, 'MEMORY.md'), 'utf-8');
     expect(content).toContain('Test memory content');
   });
 
   it('import() discovers extraFiles from config', async () => {
-    // Create additional files in workspace
     await writeFile(join(workspacePath, 'HEARTBEAT.md'), '# Heartbeat\nAgent heartbeat');
     await writeFile(join(workspacePath, 'PLAYBOOK.md'), '# Playbook\nAgent playbook');
 
@@ -178,7 +151,6 @@ describe('OpenClawAdapter', () => {
     });
     const result = await extraAdapter.import(workspacePath);
 
-    // Should still import the base files without errors
     expect(result.errors.length).toBe(0);
     expect(result.imported.length).toBeGreaterThan(0);
   });
@@ -187,30 +159,20 @@ describe('OpenClawAdapter', () => {
     const extraAdapter = new OpenClawAdapter({
       vaultPath,
       backupsPath,
-      extraFiles: ['MEMORY.md'], // Already in the default list
+      extraFiles: ['MEMORY.md'],
     });
     const result = await extraAdapter.import(workspacePath);
 
-    // MEMORY.md should only appear once
     const memoryCount = result.imported.filter((f) => f === 'openclaw/MEMORY.md').length;
     expect(memoryCount).toBe(1);
   });
 
   describe('syncBack()', () => {
-    it('detects broken symlinks and syncs content back to vault', async () => {
+    it('detects workspace changes and syncs content to vault', async () => {
       await adapter.import(workspacePath);
-      await adapter.createSymlinks(workspacePath);
 
-      // Verify MEMORY.md is a symlink
-      let stats = await lstat(join(workspacePath, 'MEMORY.md'));
-      expect(stats.isSymbolicLink()).toBe(true);
-
-      // Simulate editor atomic save: delete symlink and write regular file
-      await unlink(join(workspacePath, 'MEMORY.md'));
+      // Edit the workspace file
       await writeFile(join(workspacePath, 'MEMORY.md'), '# Memory\nUpdated by editor');
-
-      stats = await lstat(join(workspacePath, 'MEMORY.md'));
-      expect(stats.isSymbolicLink()).toBe(false);
 
       const result = await adapter.syncBack(workspacePath);
       expect(result.synced.length).toBeGreaterThan(0);
@@ -220,34 +182,39 @@ describe('OpenClawAdapter', () => {
       const vaultContent = await readFile(join(vaultPath, 'openclaw', 'MEMORY.md'), 'utf-8');
       expect(vaultContent).toContain('Updated by editor');
 
-      // File should be a symlink again
-      stats = await lstat(join(workspacePath, 'MEMORY.md'));
-      expect(stats.isSymbolicLink()).toBe(true);
-    });
-
-    it('re-creates symlink when content is identical', async () => {
-      await adapter.import(workspacePath);
-      await adapter.createSymlinks(workspacePath);
-
-      // Simulate editor atomic save with same content
-      const originalContent = await readFile(join(workspacePath, 'MEMORY.md'), 'utf-8');
-      await unlink(join(workspacePath, 'MEMORY.md'));
-      await writeFile(join(workspacePath, 'MEMORY.md'), originalContent);
-
-      const result = await adapter.syncBack(workspacePath);
-      // Should not report as synced (content identical) but symlink should be restored
-      expect(result.synced.length).toBe(0);
-
+      // Workspace file should still be a regular file
       const stats = await lstat(join(workspacePath, 'MEMORY.md'));
-      expect(stats.isSymbolicLink()).toBe(true);
+      expect(stats.isFile()).toBe(true);
+      expect(stats.isSymbolicLink()).toBe(false);
     });
 
-    it('skips files that are still valid symlinks', async () => {
+    it('skips files with identical content', async () => {
       await adapter.import(workspacePath);
-      await adapter.createSymlinks(workspacePath);
 
-      // All files are symlinks, nothing to sync back
+      // No changes — content should match
       const result = await adapter.syncBack(workspacePath);
+      expect(result.synced.length).toBe(0);
+    });
+  });
+
+  describe('syncFromVault()', () => {
+    it('copies vault changes to workspace', async () => {
+      await adapter.import(workspacePath);
+
+      // Simulate a remote change arriving in the vault
+      await writeFile(join(vaultPath, 'openclaw', 'MEMORY.md'), '# Memory\nUpdated from cloud');
+
+      const result = await adapter.syncFromVault(workspacePath);
+      expect(result.synced.length).toBeGreaterThan(0);
+
+      const content = await readFile(join(workspacePath, 'MEMORY.md'), 'utf-8');
+      expect(content).toContain('Updated from cloud');
+    });
+
+    it('skips files already in sync', async () => {
+      await adapter.import(workspacePath);
+
+      const result = await adapter.syncFromVault(workspacePath);
       expect(result.synced.length).toBe(0);
     });
   });


### PR DESCRIPTION
## Summary

OpenClaw's bootstrap file injector and memory indexer skip symlinks entirely, treating symlinked workspace files as non-existent. Every ContextMate + OpenClaw user had **zero workspace context loaded** — no persona, no user info, no operating instructions, no long-term memory.

This PR replaces the symlink strategy across all adapters with **bidirectional copy-sync** (the Dropbox model):

- **Workspace files are now real copies** (not symlinks) — OpenClaw, editors, and all tools can read them normally
- **Vault is a local cache** for encryption and cloud sync
- **Changes flow bidirectionally**: `syncBack()` (workspace → vault) and `syncFromVault()` (vault → workspace)
- **Daemon runs bidirectional sync** on each polling interval for all adapters

## Breaking changes

| Before | After |
|--------|-------|
| `createSymlinks()` | `copyToWorkspace()` |
| `verifySymlinks()` | `verifySync()` |
| `removeSymlinks()` | `disconnect()` |
| `refreshSymlinks()` | `refreshCopies()` |
| `SymlinkResult` | `CopyResult` |
| — | New: `syncFromVault()` |

## Files changed (14 files, -832/+665 lines)

**Adapters:**
- `src/adapters/base.ts` — Removed symlink utilities (`safeSymlink`, `isSymlink`), added `filesMatch()`, `copyFromVault()`, new abstract interface
- `src/adapters/openclaw.ts` — Rewritten to copy mode
- `src/adapters/claude.ts` — Rewritten to copy mode (largest: all symlink helpers → copy helpers)
- `src/adapters/mirror.ts` — Rewritten to copy mode, `refreshSymlinks` → `refreshCopies`
- `src/adapters/index.ts` — Updated exports

**CLI:**
- `src/cli/adapter.ts` — Updated messages and method calls
- `src/cli/setup.ts` — Updated messages, daemon sections add `syncFromVault()` to intervals
- `src/cli/daemon.ts` — All intervals now bidirectional (`syncBack` + `syncFromVault`)
- `src/cli/reset.ts` — "Remove symlinks" → "Disconnect adapters"

**Sync:**
- `src/sync/engine.ts` — Removed `followSymlinks: true` from vault watcher

**Tests:**
- All three adapter test files rewritten for copy behavior + new `syncFromVault` tests

## Test plan

- [x] `npm run lint` — TypeScript compiles clean
- [x] `npm test` — All 168 tests pass (13 test files)
- [x] `npm run build` — Build succeeds
- [ ] Manual: `contextmate adapter openclaw init` → verify workspace has real files
- [ ] Manual: Edit workspace file → verify vault updated
- [ ] Manual: Simulate vault change → verify workspace updated
- [ ] Manual: Verify OpenClaw sees all files (no `[MISSING]`)

Generated with [Claude Code](https://claude.com/claude-code)